### PR TITLE
Add new JSService API

### DIFF
--- a/src/builtins.const.ts
+++ b/src/builtins.const.ts
@@ -1,0 +1,1 @@
+export const BUILT_INS = [String, Object, Symbol, Array, Number];

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -402,12 +402,17 @@ export class ContainerInstance implements Disposable {
       eager: false,
       scope: 'container',
 
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      /** @ts-ignore TypeScript is actually broken here. We've told it dependencies is of type TypeWrapper[], but it still doesn't like it? */
-      dependencies: dependencies as unknown as TypeWrapper[],
-      
       /** We allow overriding the above options via the received config object. */
       ...serviceOptions,
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      /**
+       * We override the service options with the provided dependencies here, as if we have type wrapped
+       * dependencies only, we'll obviously want to overwrite anything in the options with those.
+       * Additionally, this fixes test cases such as #151.
+       */
+      /** @ts-ignore TypeScript is actually broken here. We've told it dependencies is of type TypeWrapper[], but it still doesn't like it? */
+      dependencies: dependencies as unknown as TypeWrapper[],
     };
 
     /** If the incoming metadata is marked as multiple we mask the ID and continue saving as single value. */

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -10,7 +10,7 @@ import { EMPTY_VALUE } from './empty.const';
 import { ContainerIdentifier } from './types/container-identifier.type';
 import { ContainerScope } from './types/container-scope.type';
 import { GenericTypeWrapper, TypeWrapper } from './types/type-wrapper.type';
-import { InjectedFactory } from './types/inject-identifier.type';
+import { AnyInjectIdentifier, InjectedFactory } from './types/inject-identifier.type';
 import { isInjectedFactory } from './utils/is-inject-identifier.util';
 import { resolveToTypeWrapper } from './utils/resolve-to-type-wrapper.util';
 import { Disposable } from './types/disposable.type';

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -439,12 +439,10 @@ export class ContainerInstance implements Disposable {
     // todo: sort this out
     // I've removed the legacy "extend service if it already exists"
     // behaviour for now.
-    const existingMetadata = this.metadataMap.get(newMetadata.id);
+    // const existingMetadata = this.metadataMap.get(newMetadata.id);
 
-    {
-      /** This service hasn't been registered yet, so we register it. */
-      this.metadataMap.set(newMetadata.id, newMetadata);
-    }
+    /** This service hasn't been registered yet, so we register it. */
+    this.metadataMap.set(newMetadata.id, newMetadata);
 
     /**
      * If the service is eager, we need to create an instance immediately except

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -15,8 +15,7 @@ import { isInjectedFactory } from './utils/is-inject-identifier.util';
 import { resolveToTypeWrapper } from './utils/resolve-to-type-wrapper.util';
 import { Disposable } from './types/disposable.type';
 
-// todo: make const
-export enum ServiceIdentifierLocation {
+export const enum ServiceIdentifierLocation {
   Local = 'local',
   Parent = 'parent',
   None = 'none'

--- a/src/decorators/js-service.decorator.ts
+++ b/src/decorators/js-service.decorator.ts
@@ -1,0 +1,32 @@
+import { ServiceOptions } from "../interfaces/service-options.interface";
+import { AnyConstructable } from "../types/any-constructable.type";
+import { AnyInjectIdentifier } from "../types/inject-identifier.type";
+import { Service } from "./service.decorator";
+
+export function JSService<T extends AnyConstructable>(dependencies: AnyInjectIdentifier[], constructor: T): T;
+export function JSService<T extends AnyConstructable>(options: Omit<ServiceOptions<T>, 'dependencies'>, dependencies: AnyInjectIdentifier[], constructor: T): T;
+export function JSService<T extends AnyConstructable>(options: ServiceOptions<T>, constructor: T): T;
+
+export function JSService<T extends AnyConstructable>(
+    optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyInjectIdentifier[], 
+    dependenciesOrConstructor: AnyInjectIdentifier[] | T, 
+    maybeConstructor?: T
+): T {
+    let constructor!: T;
+
+    if (typeof dependenciesOrConstructor === 'function') {
+        constructor = dependenciesOrConstructor as T;
+        Service(optionsOrDependencies as ServiceOptions<T> & { dependencies: AnyInjectIdentifier[] })(constructor);
+    } else if (maybeConstructor) {
+        constructor = maybeConstructor;
+        Service(optionsOrDependencies, dependenciesOrConstructor)(constructor);
+    }
+
+    if (!constructor) {
+        throw new Error('The JSService overload was not used correctly.');
+    }
+
+    return constructor;
+}
+
+export type JSService<T> = T extends AnyConstructable<infer U> ? U : never;

--- a/src/decorators/js-service.decorator.ts
+++ b/src/decorators/js-service.decorator.ts
@@ -3,9 +3,59 @@ import { AnyConstructable } from "../types/any-constructable.type";
 import { AnyInjectIdentifier } from "../types/inject-identifier.type";
 import { Service } from "./service.decorator";
 
+/**
+ * Marks class as a service that can be injected using Container.
+ * Uses the default options, wherein the class can be passed to `.get` and an instance of it will be returned.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ * @experimental
+ * 
+ * @param dependencies The dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ * 
+ * @param constructor The constructor of the service to inject.
+ * 
+ * @returns The constructor.
+ */
 export function JSService<T extends AnyConstructable>(dependencies: AnyInjectIdentifier[], constructor: T): T;
+
+/**
+ * Marks class as a service that can be injected using Container.
+ * The options allow customization of how the service is injected.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ * @experimental
+ * 
+ * @param options The options to use for initialisation of the service.
+ * Documentation for the options can be found in ServiceOptions.
+ * 
+ * @param dependencies The dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ * 
+ * @param constructor The constructor of the service to inject.
+ * 
+ * @returns The constructor.
+ */
 export function JSService<T extends AnyConstructable>(options: Omit<ServiceOptions<T>, 'dependencies'>, dependencies: AnyInjectIdentifier[], constructor: T): T;
-export function JSService<T extends AnyConstructable>(options: ServiceOptions<T>, constructor: T): T;
+
+/**
+ * Marks class as a service that can be injected using Container.
+ * The options allow customization of how the service is injected.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ * 
+ * @param options The options to use for initialisation of the service.
+ * Documentation for the options can be found in ServiceOptions.
+ * The options must also contain the dependencies that the service requires.
+ * 
+ * If found, the specified dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ * 
+ * @param constructor The constructor of the service to inject.
+ * 
+ * @returns The constructor.
+ */
+export function JSService<T extends AnyConstructable>(options: ServiceOptions<T> & { dependencies: AnyInjectIdentifier[] }, constructor: T): T;
 
 export function JSService<T extends AnyConstructable>(
     optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyInjectIdentifier[], 

--- a/src/error/cannot-instantiate-builtin-error.ts
+++ b/src/error/cannot-instantiate-builtin-error.ts
@@ -1,0 +1,10 @@
+import { CannotInstantiateValueError } from "./cannot-instantiate-value.error";
+
+/**
+ * Thrown when DI encounters a service depending on a built-in type (Number, String) with no factory.
+ */
+export class CannotInstantiateBuiltInError extends CannotInstantiateValueError {
+    get message () {
+        return super.message + ` If your service requires built-in or unresolvable types, please use a factory.`;
+    }
+}

--- a/src/types/js-service.type.ts
+++ b/src/types/js-service.type.ts
@@ -1,0 +1,3 @@
+import { AnyConstructable } from "./any-constructable.type";
+
+export type JSService<T extends AnyConstructable> = T;

--- a/test/Container.spec.ts
+++ b/test/Container.spec.ts
@@ -11,8 +11,8 @@ describe('Container', function () {
     it('should be able to get a boolean', () => {
       const booleanTrue = 'boolean.true';
       const booleanFalse = 'boolean.false';
-      Container.set({ id: booleanTrue, value: true });
-      Container.set({ id: booleanFalse, value: false });
+      Container.set({ id: booleanTrue, value: true, dependencies: [] });
+      Container.set({ id: booleanFalse, value: false, dependencies: [] });
 
       expect(Container.get(booleanTrue)).toBe(true);
       expect(Container.get(booleanFalse)).toBe(false);
@@ -20,14 +20,14 @@ describe('Container', function () {
 
     it('should be able to get an empty string', () => {
       const emptyString = 'emptyString';
-      Container.set({ id: emptyString, value: '' });
+      Container.set({ id: emptyString, value: '', dependencies: [] });
 
       expect(Container.get(emptyString)).toBe('');
     });
 
     it('should be able to get the 0 number', () => {
       const zero = 'zero';
-      Container.set({ id: zero, value: 0 });
+      Container.set({ id: zero, value: 0, dependencies: [] });
 
       expect(Container.get(zero)).toBe(0);
     });
@@ -39,7 +39,7 @@ describe('Container', function () {
         constructor(public name: string) {}
       }
       const testService = new TestService('this is test');
-      Container.set({ id: TestService, value: testService });
+      Container.set({ id: TestService, value: testService, dependencies: [] });
       expect(Container.get(TestService)).toBe(testService);
       expect(Container.get(TestService).name).toBe('this is test');
     });
@@ -49,10 +49,10 @@ describe('Container', function () {
         constructor(public name: string) {}
       }
       const firstService = new TestService('first');
-      Container.set({ id: 'first.service', value: firstService });
+      Container.set({ id: 'first.service', value: firstService, dependencies: [String] });
 
       const secondService = new TestService('second');
-      Container.set({ id: 'second.service', value: secondService });
+      Container.set({ id: 'second.service', value: secondService, dependencies: [String] });
 
       expect(Container.get<TestService>('first.service').name).toBe('first');
       expect(Container.get<TestService>('second.service').name).toBe('second');
@@ -66,10 +66,10 @@ describe('Container', function () {
       const SecondTestToken = new Token<TestService>();
 
       const firstService = new TestService('first');
-      Container.set({ id: FirstTestToken, value: firstService });
+      Container.set({ id: FirstTestToken, value: firstService, dependencies: [] });
 
       const secondService = new TestService('second');
-      Container.set({ id: SecondTestToken, value: secondService });
+      Container.set({ id: SecondTestToken, value: secondService, dependencies: [] });
 
       expect(Container.get(FirstTestToken).name).toBe('first');
       expect(Container.get(SecondTestToken).name).toBe('second');
@@ -82,12 +82,12 @@ describe('Container', function () {
       const TestToken = new Token<TestService>();
 
       const firstService = new TestService('first');
-      Container.set({ id: TestToken, value: firstService });
+      Container.set({ id: TestToken, value: firstService, dependencies: [String] });
       expect(Container.get(TestToken)).toBe(firstService);
       expect(Container.get(TestToken).name).toBe('first');
 
       const secondService = new TestService('second');
-      Container.set({ id: TestToken, value: secondService });
+      Container.set({ id: TestToken, value: secondService, dependencies: [String] });
 
       expect(Container.get(TestToken)).toBe(secondService);
       expect(Container.get(TestToken).name).toBe('second');
@@ -108,10 +108,10 @@ describe('Container', function () {
       const test1Service = new TestService();
       const test2Service = new TestService();
 
-      Container.set({ id: TestService, value: testService });
-      Container.set({ id: 'test1-service', value: test1Service });
-      Container.set({ id: 'test2-service', value: test2Service });
-      Container.set({ id: 'test3-service', factory: [TestServiceFactory, 'create'] });
+      Container.set({ id: TestService, value: testService, dependencies: [] });
+      Container.set({ id: 'test1-service', value: test1Service, dependencies: [] });
+      Container.set({ id: 'test2-service', value: test2Service, dependencies: [] });
+      Container.set({ id: 'test3-service', factory: [TestServiceFactory, 'create'], dependencies: [] });
 
       expect(Container.get(TestService)).toBe(testService);
       expect(Container.get<TestService>('test1-service')).toBe(test1Service);
@@ -131,9 +131,9 @@ describe('Container', function () {
       const test1Service = new TestService();
       const test2Service = new TestService();
 
-      Container.set({ id: TestService, value: testService });
-      Container.set({ id: 'test1-service', value: test1Service });
-      Container.set({ id: 'test2-service', value: test2Service });
+      Container.set({ id: TestService, value: testService, dependencies: [] });
+      Container.set({ id: 'test1-service', value: test1Service, dependencies: [] });
+      Container.set({ id: 'test2-service', value: test2Service, dependencies: [] });
 
       expect(Container.get(TestService)).toBe(testService);
       expect(Container.get<TestService>('test1-service')).toBe(test1Service);
@@ -154,7 +154,7 @@ describe('Container', function () {
         constructor(public name: string = 'frank') {}
       }
 
-      Container.set({ id: TestService, type: TestService });
+      Container.set({ id: TestService, type: TestService, dependencies: [] });
       const testService = Container.get(TestService);
       testService.name = 'john';
 
@@ -179,6 +179,7 @@ describe('Container', function () {
       Container.set({
         id: Car,
         factory: () => new Car(new Engine()),
+        dependencies: [Engine]
       });
 
       expect(Container.get(Car).engine.serialNumber).toBe('A-123');
@@ -206,6 +207,7 @@ describe('Container', function () {
       Container.set({
         id: Car,
         factory: [CarFactory, 'createCar'],
+        dependencies: [Engine]
       });
 
       expect(Container.get(Car).engine.serialNumber).toBe('A-123');
@@ -233,6 +235,7 @@ describe('Container', function () {
       Container.set({
         id: VehicleService,
         factory: [VehicleFactory, 'createBus'],
+        dependencies: []
       });
 
       expect(Container.get(VehicleService).getColor()).toBe('yellow');

--- a/test/decorators/JSService.spec.ts
+++ b/test/decorators/JSService.spec.ts
@@ -1,0 +1,83 @@
+import Container from '../../src/index';
+import { JSService } from '../../src/decorators/js-service.decorator';
+import { AnyConstructable } from '../types/any-constructable.type';
+
+describe('JSService decorator', () => {
+    beforeEach(() => Container.reset({ strategy: 'resetValue' }));
+
+    type InstanceOf<T> = T extends AnyConstructable<infer U> ? U : never;
+
+    it('should take dependencies and constructor', () => {
+        type AnotherService = InstanceOf<typeof AnotherService>;
+        const AnotherService = JSService([], class AnotherService {
+            getMeaningOfLife () {
+                return 42;
+            }
+        });
+
+        type MyService = InstanceOf<typeof MyService>;
+        const MyService = JSService([AnotherService], class MyService {
+            constructor (public anotherService: AnotherService) { }
+        });
+
+        expect(Container.has(MyService)).toBe(true);
+        expect(Container.has(AnotherService)).toBe(true);
+        expect(Container.get(MyService).anotherService.getMeaningOfLife()).toStrictEqual(42);
+    });
+
+    it('should take options without dependencies, list of dependencies and constructor', () => {
+        type AnotherService = InstanceOf<typeof AnotherService>;
+        const AnotherService = JSService([], class AnotherService {
+            getMeaningOfLife () {
+                return 42;
+            }
+        });
+
+        type MyService = InstanceOf<typeof MyService>;
+        const MyService = JSService({ }, [AnotherService], class MyService {
+            public anotherService: AnotherService;
+
+            constructor (anotherService: AnotherService) {
+                this.anotherService = anotherService;
+            }
+        });
+
+        expect(Container.has(MyService)).toBe(true);
+        expect(Container.has(AnotherService)).toBe(true);
+        expect(Container.get(MyService).anotherService.getMeaningOfLife()).toStrictEqual(42);
+    });
+
+    it('should take options with dependencies and constructor', () => {
+        type AnotherService = InstanceOf<typeof AnotherService>;
+        const AnotherService = JSService([], class AnotherService {
+            getMeaningOfLife () {
+                return 42;
+            }
+        });
+
+        type MyService = InstanceOf<typeof MyService>;
+        const MyService = JSService({ dependencies: [AnotherService] }, class MyService {
+            public anotherService: AnotherService;
+
+            constructor (anotherService: AnotherService) {
+                this.anotherService = anotherService;
+            }
+        });
+
+        expect(Container.has(MyService)).toBe(true);
+        expect(Container.has(AnotherService)).toBe(true);
+        expect(Container.get(MyService).anotherService.getMeaningOfLife()).toStrictEqual(42);
+    });
+
+    it('should provide a functioning JSService type', () => {
+        const MyService = JSService([], class MyService {
+            getOne () {
+                return 1;
+            }
+        });
+
+        type MyService = JSService<typeof MyService>;
+        
+        const myService: MyService = Container.get(MyService);
+    });
+});

--- a/test/eager-loading-services.spec.ts
+++ b/test/eager-loading-services.spec.ts
@@ -13,8 +13,8 @@ describe('Eager loading of services', function () {
         public createdAt = callOrder++;
       }
 
-      Container.set({ id: 'eager-service', type: MyService, eager: true });
-      Container.set({ id: 'lazy-service', type: MyService, eager: false });
+      Container.set({ id: 'eager-service', type: MyService, eager: true, dependencies: [] });
+      Container.set({ id: 'lazy-service', type: MyService, eager: false, dependencies: [] });
 
       const timeStampBeforeRequests = callOrder++;
 
@@ -37,12 +37,12 @@ describe('Eager loading of services', function () {
     it('should be able to set eager and lazy service with @Service decorator', () => {
       let callOrder = 1;
 
-      @Service({ eager: true })
+      @Service({ eager: true }, [])
       class MyEagerService {
         public createdAt = callOrder++;
       }
 
-      @Service({ eager: false })
+      @Service({ eager: false }, [])
       class MyLazyService {
         public createdAt = callOrder++;
       }

--- a/test/github-issues/151/issue-151.spec.ts
+++ b/test/github-issues/151/issue-151.spec.ts
@@ -1,6 +1,5 @@
 import 'reflect-metadata';
-import { Container } from '../../index';
-import { Service } from '../../decorators/service.decorator';
+import { Container, Service } from '../../../src/index';
 
 describe('Github Issues', function () {
   beforeEach(() => Container.reset({ strategy: 'resetValue' }));
@@ -21,12 +20,13 @@ describe('Github Issues', function () {
     class DataService {
       constructor(public authService: AuthService) {}
     }
+
     @Service([AuthService])
     class FakeDataService {
       constructor(public authService: AuthService) {}
     }
 
-    Container.set({ id: DataService, type: FakeDataService });
+    Container.set({ id: DataService, type: FakeDataService, dependencies: [AuthService] });
 
     const instance = Container.get<FakeDataService>(DataService as any);
 

--- a/test/github-issues/157/issue-157.spec.ts
+++ b/test/github-issues/157/issue-157.spec.ts
@@ -8,7 +8,7 @@ describe('Github Issues', function () {
   it('#157 - reset should not break transient services', () => {
     let creationCounter = 0;
 
-    @Service({ scope: 'transient' })
+    @Service({ scope: 'transient' }, [])
     class TransientService {
       public constructor() {
         creationCounter++;

--- a/test/github-issues/41/issue-41.spec.ts
+++ b/test/github-issues/41/issue-41.spec.ts
@@ -22,16 +22,16 @@ describe('github issues > #41 Token as service id in combination with factory', 
     @Service({
       id: SomeInterfaceToken,
       factory: [SomeInterfaceFactory, 'create'],
-    })
+    }, [])
     class SomeImplementation implements SomeInterface {
       foo() {
         return 'hello implementation';
       }
     }
 
-    Container.set({ id: 'moment', value: 'A' });
-    Container.set({ id: 'jsonwebtoken', value: 'B' });
-    Container.set({ id: 'cfg.auth.jwt', value: 'C' });
+    Container.set({ id: 'moment', value: 'A', dependencies: [] });
+    Container.set({ id: 'jsonwebtoken', value: 'B', dependencies: [] });
+    Container.set({ id: 'cfg.auth.jwt', value: 'C', dependencies: [] });
     const someInterfaceImpl = Container.get(SomeInterfaceToken);
     expect(someInterfaceImpl.foo()).toBe('hello implementation');
   });

--- a/test/github-issues/48/issue-48.spec.ts
+++ b/test/github-issues/48/issue-48.spec.ts
@@ -11,7 +11,7 @@ describe("github issues > #48 Token service iDs in global container aren't inher
 
     const FooServiceToken = new Token<FooService>();
 
-    @Service({ id: FooServiceToken })
+    @Service({ id: FooServiceToken }, [])
     class FooService implements FooService {
       public marco() {
         poloCounter++;


### PR DESCRIPTION
This PR adds an experimental new JSService API that can be used to simplify the creation
and management of services from plain JavaScript.

A new `JSService` type is also introduced.  This allows consumers to take advantage of
TypeScript's allowance for a type and a value to share the same name, wherein TypeScript
then figures out which one we're referring to.

## Example

```ts
type AnotherService = JSService<typeof AnotherService>;
const AnotherService = JSService([], class AnotherService {
    getMeaningOfLife() {
        return 42;
    }
});

type MyService = JSService<typeof MyService>;
const MyService = JSService([AnotherService], class MyService {
    constructor(public anotherService: AnotherService) { }
});
```

*(The above example will run in JavaScript with the type declaration and `public:` removed.)*