### PR TITLE
Visitor (ContainerTreeVisitor) API

### DIFF
--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -276,6 +276,12 @@ export class ContainerInstance implements Disposable {
     this[THROW_IF_DISPOSED]();
 
     /**
+     * Notify any listeners of the retrieval request before
+     * we check if the identifier is resolvable in the container.
+     */
+    this.visitor.visitRetrieval(identifier, { recursive, many: false });
+
+    /**
      * Provide compatibility with the `HostContainer()` API.
      */
     if (identifier === HOST_CONTAINER) {
@@ -397,6 +403,12 @@ export class ContainerInstance implements Disposable {
     this[THROW_IF_DISPOSED]();
 
     let idMap: ManyServicesMetadata | void = undefined;
+
+    /**
+     * Notify any listeners of the retrieval request before
+     * we check if the identifier is resolvable in the container.
+     */
+    this.visitor.visitRetrieval(identifier, { recursive, many: true });
 
     if (!this.multiServiceIds.has(identifier)) {
       /** If this container has no knowledge of the identifier, then we check the parent (if we have one). */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
-/** This is an internal package, so we don't re-export it on purpose. */
-import { ContainerInstance } from './container-instance.class';
-
 export { JSService } from './decorators/js-service.decorator';
 export { Service } from './decorators/service.decorator';
 
@@ -33,5 +30,4 @@ export { ContainerInstance } from './container-instance.class';
 export { Token } from './token.class';
 
 /** We export the default container under the Container alias. */
-export const Container = ContainerInstance.defaultContainer;
-export default Container;
+export { defaultContainer as Container, defaultContainer as default } from './container-instance.class';

--- a/src/interfaces/tree-visitor.interface.ts
+++ b/src/interfaces/tree-visitor.interface.ts
@@ -1,28 +1,36 @@
-import { ContainerInstance } from "../container-instance.class";
-import { Disposable } from "../types/disposable.type";
-import { ServiceIdentifier } from "../types/service-identifier.type";
-import { ServiceMetadata } from "./service-metadata.interface";
+import { ContainerInstance, ServiceIdentifierLocation } from '../container-instance.class';
+import { Disposable } from '../types/disposable.type';
+import { ServiceIdentifier } from '../types/service-identifier.type';
+import { ServiceMetadata } from './service-metadata.interface';
 
 /**
  * A collection of options passed to {@link ContainerTreeVisitor.visitRetrieval}.
  */
 export interface VisitRetrievalOptions {
-    /**
-     * Whether the request was recursive.
-     * If the option was not specified in the request, defaults to `true`.
-     */
-    recursive: boolean;
+  /**
+   * Whether the request was recursive.
+   * If the option was not specified in the request, defaults to `true`.
+   */
+  recursive: boolean;
 
-    /**
-     * If true, the identifier was requested via the following methods:
-     *   - {@link ContainerInstance.getMany}
-     *   - {@link ContainerInstance.getManyOrNull}
-     * 
-     * Otherwise, the identifier was requested using:
-     *   - {@link ContainerInstance.get}
-     *   - {@link ContainerInstance.getOrNull}.
-     */
-    many: boolean;
+  /**
+   * If true, the identifier was requested via the following methods:
+   *   - {@link ContainerInstance.getMany}
+   *   - {@link ContainerInstance.getManyOrNull}
+   *
+   * Otherwise, the identifier was requested using:
+   *   - {@link ContainerInstance.get}
+   *   - {@link ContainerInstance.getOrNull}.
+   */
+  many: boolean;
+
+  /**
+   * The location of the identifier, or {@link ServiceIdentifierLocation.None}
+   * if the identifier could not be found.
+   *
+   * @see {@link ServiceIdentifierLocation}
+   */
+  location: ServiceIdentifierLocation;
 }
 
 /**
@@ -89,66 +97,57 @@ export interface VisitRetrievalOptions {
  * (This is a very simplified example and use-case.)
  */
 export interface ContainerTreeVisitor extends Disposable {
-    /**
-     * Visit a child container of the current service.
-     * @experimental
-     * 
-     * @param child The newly-created child container of the current instance.
-     */
-    visitChildContainer? (child: ContainerInstance): void;
+  /**
+   * Visit a child container of the current service.
+   * @experimental
+   *
+   * @param child The newly-created child container of the current instance.
+   */
+  visitChildContainer?(child: ContainerInstance): void;
 
-    /**
-     * Visit a container with no parent.
-     * This is only called if the visitor was attached to the default container.
-     * @experimental
-     * 
-     * @param container The newly-created container.
-     */
-    visitOrphanedContainer? (container: ContainerInstance): void;
+  /**
+   * Visit a container with no parent.
+   * This is only called if the visitor was attached to the default container.
+   * @experimental
+   *
+   * @param container The newly-created container.
+   */
+  visitOrphanedContainer?(container: ContainerInstance): void;
 
-    /**
-     * Visit a new service being added to the container.
-     * This is called when a new service is added via `Container.set(...)`.
-     * @experimental
-     * 
-     * @param serviceOptions The options of the new service.
-     */
-    visitNewService? (serviceOptions: ServiceMetadata<unknown>): void;
+  /**
+   * Visit a new service being added to the container.
+   * This is called when a new service is added via `Container.set(...)`.
+   * @experimental
+   *
+   * @param serviceOptions The options of the new service.
+   */
+  visitNewService?(serviceOptions: ServiceMetadata<unknown>): void;
 
-    /**
-     * Visit the given container.
-     * This is called as a result of `Container.acceptTreeVisitor(...)`.
-     * @experimental
-     * 
-     * @param container The container to visit.
-     * 
-     * @returns Whether the visitor can be attached to the container.
-     * If `false` is returned, no notifications are sent from the provided container.
-     * Otherwise, all notifications from the passed are sent to the visitor.
-     */
-    visitContainer? (container: ContainerInstance): boolean;
+  /**
+   * Visit the given container.
+   * This is called as a result of `Container.acceptTreeVisitor(...)`.
+   * @experimental
+   *
+   * @param container The container to visit.
+   *
+   * @returns Whether the visitor can be attached to the container.
+   * If `false` is returned, no notifications are sent from the provided container.
+   * Otherwise, all notifications from the passed are sent to the visitor.
+   */
+  visitContainer?(container: ContainerInstance): boolean;
 
-    /**
-     * Visit an unavailable service in the given container.
-     * This is called when a given identifier cannot be found in the container.
-     * @experimental
-     * 
-     * @param identifier The identifier of the unavailable service.
-     */
-    visitUnavailableService? (identifier: ServiceIdentifier, many: boolean): void;
-
-    /**
-     * Visit a request for a container to retrieve a service.
-     * @experimental
-     *
-     * This is similar to the `visitUnavailableService` handler, but it
-     * is always called in the event of service retrieval.
-     * If the identifier can not be found, `visitUnavailableService` is then called.
-     *
-     * @param identifier The identifier of the requested service.
-     *
-     * @param options A set of options passed to the listener.
-     * Documented in {@link VisitRetrievalOptions}.
-     */
-    visitRetrieval? (identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void;
+  /**
+   * Visit a request for a container to retrieve a service.
+   * @experimental
+   *
+   * This is similar to the `visitUnavailableService` handler, but it
+   * is always called in the event of service retrieval.
+   * If the identifier can not be found, `visitUnavailableService` is then called.
+   *
+   * @param identifier The identifier of the requested service.
+   *
+   * @param options A set of options passed to the listener.
+   * Documented in {@link VisitRetrievalOptions}.
+   */
+  visitRetrieval?(identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void;
 }

--- a/src/interfaces/tree-visitor.interface.ts
+++ b/src/interfaces/tree-visitor.interface.ts
@@ -1,0 +1,53 @@
+import { ContainerInstance } from "../container-instance.class";
+import { Disposable } from "../types/disposable.type";
+import { ServiceIdentifier } from "../types/service-identifier.type";
+import { ServiceOptions } from "./service-options.interface";
+
+/**
+ * A visitor for Container objects, which allows for extension of container functionality.
+ * @experimental
+ */
+export interface ContainerTreeVisitor extends Disposable {
+    /**
+     * Visit a child container of the current service.
+     * @experimental
+     * 
+     * @param child The newly-created child container of the current instance.
+     */
+    visitChildContainer? (child: ContainerInstance): void;
+
+    /**
+     * Visit a container with no parent.
+     * @experimental
+     * 
+     * @param container The newly-created container.
+     */
+    visitOrphanedContainer? (container: ContainerInstance): void;
+
+    /**
+     * Visit a new service being added to the container.
+     * This is called when a new service is added via `Container.set(...)`.
+     * @experimental
+     * 
+     * @param serviceOptions The options of the new service.
+     */
+    visitNewService? (serviceOptions: ServiceOptions<unknown>): void;
+
+    /**
+     * Visit the given container.
+     * This is called as a result of `Container.acceptVisitor(...)`.
+     * @experimental
+     * 
+     * @param container The container to visit.
+     */
+    visitContainer? (container: ContainerInstance): void;
+
+    /**
+     * Visit an unavailable service in the given container.
+     * This is called when a given identifier cannot be found in the container.
+     * @experimental
+     * 
+     * @param identifier The identifier of the unavailable service.
+     */
+    visitUnavailableService? (identifier: ServiceIdentifier): void;
+}

--- a/src/interfaces/tree-visitor.interface.ts
+++ b/src/interfaces/tree-visitor.interface.ts
@@ -4,6 +4,28 @@ import { ServiceIdentifier } from "../types/service-identifier.type";
 import { ServiceMetadata } from "./service-metadata.interface";
 
 /**
+ * A collection of options passed to {@link ContainerTreeVisitor.visitRetrieval}.
+ */
+export interface VisitRetrievalOptions {
+    /**
+     * Whether the request was recursive.
+     * If the option was not specified in the request, defaults to `true`.
+     */
+    recursive: boolean;
+
+    /**
+     * If true, the identifier was requested via the following methods:
+     *   - {@link ContainerInstance.getMany}
+     *   - {@link ContainerInstance.getManyOrNull}
+     * 
+     * Otherwise, the identifier was requested using:
+     *   - {@link ContainerInstance.get}
+     *   - {@link ContainerInstance.getOrNull}.
+     */
+    many: boolean;
+}
+
+/**
  * A visitor for Container objects, which allows for extension of container functionality.
  * @experimental **This API is still being developed.  It will probably change.**
  * 
@@ -114,4 +136,19 @@ export interface ContainerTreeVisitor extends Disposable {
      * @param identifier The identifier of the unavailable service.
      */
     visitUnavailableService? (identifier: ServiceIdentifier, many: boolean): void;
+
+    /**
+     * Visit a request for a container to retrieve a service.
+     * @experimental
+     *
+     * This is similar to the `visitUnavailableService` handler, but it
+     * is always called in the event of service retrieval.
+     * If the identifier can not be found, `visitUnavailableService` is then called.
+     *
+     * @param identifier The identifier of the requested service.
+     *
+     * @param options A set of options passed to the listener.
+     * Documented in {@link VisitRetrievalOptions}.
+     */
+    visitRetrieval? (identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void;
 }

--- a/src/interfaces/tree-visitor.interface.ts
+++ b/src/interfaces/tree-visitor.interface.ts
@@ -99,8 +99,12 @@ export interface ContainerTreeVisitor extends Disposable {
      * @experimental
      * 
      * @param container The container to visit.
+     * 
+     * @returns Whether the visitor can be attached to the container.
+     * If `false` is returned, no notifications are sent from the provided container.
+     * Otherwise, all notifications from the passed are sent to the visitor.
      */
-    visitContainer? (container: ContainerInstance): void;
+    visitContainer? (container: ContainerInstance): boolean;
 
     /**
      * Visit an unavailable service in the given container.

--- a/src/interfaces/tree-visitor.interface.ts
+++ b/src/interfaces/tree-visitor.interface.ts
@@ -1,11 +1,70 @@
 import { ContainerInstance } from "../container-instance.class";
 import { Disposable } from "../types/disposable.type";
 import { ServiceIdentifier } from "../types/service-identifier.type";
-import { ServiceOptions } from "./service-options.interface";
+import { ServiceMetadata } from "./service-metadata.interface";
 
 /**
  * A visitor for Container objects, which allows for extension of container functionality.
- * @experimental
+ * @experimental **This API is still being developed.  It will probably change.**
+ * 
+ *
+ * To aid usage of this API, some noteworthy points can be found below.
+ * 
+ * ## Visitors are Singletons (sort of)
+ * 
+ * By design, the visitor API is designed in such a manner that
+ * each visitor can only be feasibly attached to a single container.
+ * 
+ * _This applies to child containers too_: any notifications from child
+ * containers will not bubble up and trigger notifications on parent
+ * containers.
+ * 
+ * The API does not prevent attaching a *new* visitor to any containers
+ * passed to the visitor through either `visitOrpahanedContainer` or
+ * `visitChildContainer`.  _This is the recommended approach._
+ * 
+ * ## Recursive Calls
+ * 
+ * _The API does not protect against recursion._
+ * If, for example, the consumer adds a new service to the container in the
+ * `visitNewService` method, there will be an infinite loop.
+ * This can be remedied by guarding against any further recursive calls
+ * for services added by the visitor; the implementation of that is left
+ * to the consumer.
+ * 
+ * ## Container Reference
+ * 
+ * When a visitor is attached to a container, its `visitContainer` method is called.
+ * This allows the visitor to then hold a persistent reference to said container,
+ * allowing it to interact with the container as a regular consumer.
+ * Therefore, the container the visitor is bound to is not passed for each function call.
+ * It is up to the consumer to store the container and then perform operations on it later.
+ * 
+ * One important point which relates to the singleton aspect of the API design is that,
+ * as a recommended approach, if the visitor's `visitContainer` is called more than once,
+ * the later values should be ignored -- this was most likely caused due to the visitor
+ * being added to more than one container.
+ * 
+ * ---
+ * 
+ * @example
+ * A simple example of the visitor API is as follows:
+ * ```ts
+ * class LoggingTreeVisitor implements ContainerTreeVisitor {
+ *   public container!: ContainerIdentifier;
+ * 
+ *   visitContainer (container: ContainerIdentifier) {
+ *     if (!this.container) {
+ *       this.container = container;
+ *     }
+ *   }
+ * 
+ *   visitNewService (options: ServiceOptions<unknown>) {
+ *     console.log('New service added to container: ', options.id);
+ *   }
+ * }
+ * ```
+ * (This is a very simplified example and use-case.)
  */
 export interface ContainerTreeVisitor extends Disposable {
     /**
@@ -18,6 +77,7 @@ export interface ContainerTreeVisitor extends Disposable {
 
     /**
      * Visit a container with no parent.
+     * This is only called if the visitor was attached to the default container.
      * @experimental
      * 
      * @param container The newly-created container.
@@ -31,11 +91,11 @@ export interface ContainerTreeVisitor extends Disposable {
      * 
      * @param serviceOptions The options of the new service.
      */
-    visitNewService? (serviceOptions: ServiceOptions<unknown>): void;
+    visitNewService? (serviceOptions: ServiceMetadata<unknown>): void;
 
     /**
      * Visit the given container.
-     * This is called as a result of `Container.acceptVisitor(...)`.
+     * This is called as a result of `Container.acceptTreeVisitor(...)`.
      * @experimental
      * 
      * @param container The container to visit.
@@ -49,5 +109,5 @@ export interface ContainerTreeVisitor extends Disposable {
      * 
      * @param identifier The identifier of the unavailable service.
      */
-    visitUnavailableService? (identifier: ServiceIdentifier): void;
+    visitUnavailableService? (identifier: ServiceIdentifier, many: boolean): void;
 }

--- a/src/visitor-collection.class.ts
+++ b/src/visitor-collection.class.ts
@@ -1,0 +1,165 @@
+import { ContainerInstance } from "./container-instance.class";
+import { ServiceMetadata } from "./interfaces/service-metadata.interface";
+import { ContainerTreeVisitor } from "./interfaces/tree-visitor.interface";
+import { Disposable } from "./types/disposable.type";
+import { ServiceIdentifier } from "./types/service-identifier.type";
+
+/**
+ * A collection of individual visitor objects, combined into a collection.
+ * @experimental
+ * 
+ * This interface implements everything but "visitContainer", as that
+ * should never be done at random for all elements.
+ * Instead, it is done in the "addVisitor" method.
+ * 
+ * The class is implemented in a semi-stateless fashion: it holds no
+ * persistent references to any particular collection.
+ */
+export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor, 'visitContainer'> {
+    /** Whether the instance is disposed. */
+    public disposed = false;
+
+    /** The visitors stored within the collection. */
+    protected visitors: ContainerTreeVisitor[] = [];
+
+    /**
+     * A flag stating whether any visitors are currently present in the collection.
+     * If not, all notifications will be ignored.
+     * 
+     * This is mostly for optimisation.
+     */
+    protected anyVisitorsPresent = false;
+
+    /**
+     * A flag which states whether any visitors should be notified.
+     * If the collection has been disposed or no visitors are present,
+     * this evaluates to `false`.
+     */
+    protected get notifyVisitors () {
+        return !this.disposed && this.anyVisitorsPresent;
+    }
+
+    constructor () { }
+
+    // the implementation below is very simple, there is definitely room for improvement.
+
+    /**
+     * Iterate the list of visitors, excluding any which have been disposed.
+     * Does not perform any iteration if no visitors are present.
+     * 
+     * @param callback A function to call for each visitor in the collection.
+     */
+    public forEach (callback: { (visitor: ContainerTreeVisitor ): void }) {
+        if (this.notifyVisitors) {
+            this.visitors.forEach(visitor => {
+                /** If the visitor has been disposed since the last iteration, free it from the store. */
+                if (visitor.disposed) {
+                    this.removeVisitor(visitor);
+                    return;
+                }
+
+                /** Disposed visitors should not be notified. */
+                callback(visitor);
+            });
+        }
+    }
+
+    visitChildContainer(child: ContainerInstance): void {
+        this.forEach(visitor => visitor.visitChildContainer?.(child));
+    }
+
+    visitOrphanedContainer(container: ContainerInstance): void {
+        this.forEach(visitor => visitor.visitOrphanedContainer?.(container));
+    }
+
+    visitNewService(serviceOptions: ServiceMetadata<unknown>): void {
+        this.forEach(visitor => visitor.visitNewService?.(serviceOptions));
+    }
+
+    visitContainer(container: ContainerInstance): void {
+        this.forEach(visitor => visitor.visitContainer?.(container));
+    }
+
+    visitUnavailableService(identifier: ServiceIdentifier, many: boolean): void {
+        this.forEach(visitor => visitor.visitUnavailableService?.(identifier, many));
+    }
+
+    /**
+     * Add a visitor to the collection.
+     * @experimental
+     * 
+     * @param visitor The visitor to append to the collection.
+     * @param container The container to initialise the container on.
+     */
+    addVisitor(visitor: ContainerTreeVisitor, container: ContainerInstance) {
+        /** If the visitor is already present, do not add another. */
+        if (this.visitors.includes(visitor)) {
+            return false;
+        }
+
+        this.visitors.push(visitor);
+
+        /**
+         * Mark the collection as having visitors present, so
+         * it doesn't ignore any events passed to it.
+         */
+        if (!this.anyVisitorsPresent) {
+            this.anyVisitorsPresent = true;
+        }
+
+        // todo: should visitContainer return false?
+        // this could result in the collection removing it. we'd need to keep the visitor in-place initially,
+        // as if the container calls .get or anything in its visitContainer method, it would most likely want to
+        // get called if the service was unavailable / any new ones were added, etc.
+
+        /**
+         * Directly call the visitor's "visitContainer" method
+         * to initialise it upon the given container.
+         * 
+         * Implementation detail: We don't provide any sort of protection against 
+         * this being called again on a different container.
+         * The visitor would be able to handle that themselves, as the API states
+         * that any call to `visitContainer` means that the visitor was added
+         * to a container.
+         */
+        visitor.visitContainer?.(container);
+        return true;
+    }
+
+    /**
+     * Remove a visitor from the collection,
+     * if it was already present.
+     * @experimental
+     * 
+     * @param visitor The visitor to remove from the collection.
+     */
+    removeVisitor(visitor: ContainerTreeVisitor) {
+        const indexOfVisitor = this.visitors.indexOf(visitor);
+
+        if (indexOfVisitor === -1) {
+            return false;
+        }
+
+        /** Remove the element from the array via "splice". */
+        this.visitors.splice(indexOfVisitor, 1);
+
+        /** Re-evalute the length of the visitors array and recompute anyVisitorsPresent. */
+        if (this.visitors.length === 0) {
+            this.anyVisitorsPresent = false;
+        }
+
+        return true;
+    }
+
+    public dispose() {
+        /** Prevent duplicate calls to dispose. */
+        if (this.disposed) {
+            return;
+        }
+
+        this.disposed = true;
+
+        /** Notify all containers of disposal. */
+        this.forEach(visitor => visitor.dispose());
+    }
+}

--- a/src/visitor-collection.class.ts
+++ b/src/visitor-collection.class.ts
@@ -76,10 +76,6 @@ export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor,
         this.forEach(visitor => visitor.visitNewService?.(serviceOptions));
     }
 
-    visitContainer(container: ContainerInstance): void {
-        this.forEach(visitor => visitor.visitContainer?.(container));
-    }
-
     visitUnavailableService(identifier: ServiceIdentifier, many: boolean): void {
         this.forEach(visitor => visitor.visitUnavailableService?.(identifier, many));
     }

--- a/src/visitor-collection.class.ts
+++ b/src/visitor-collection.class.ts
@@ -1,6 +1,6 @@
 import { ContainerInstance } from "./container-instance.class";
 import { ServiceMetadata } from "./interfaces/service-metadata.interface";
-import { ContainerTreeVisitor } from "./interfaces/tree-visitor.interface";
+import { ContainerTreeVisitor, VisitRetrievalOptions } from "./interfaces/tree-visitor.interface";
 import { Disposable } from "./types/disposable.type";
 import { ServiceIdentifier } from "./types/service-identifier.type";
 
@@ -78,6 +78,10 @@ export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor,
 
     visitUnavailableService(identifier: ServiceIdentifier, many: boolean): void {
         this.forEach(visitor => visitor.visitUnavailableService?.(identifier, many));
+    }
+
+    visitRetrieval(identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void {
+        this.forEach(visitor => visitor.visitRetrieval?.(identifier, options));
     }
 
     /**

--- a/src/visitor-collection.class.ts
+++ b/src/visitor-collection.class.ts
@@ -107,11 +107,6 @@ export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor,
             this.anyVisitorsPresent = true;
         }
 
-        // todo: should visitContainer return false?
-        // this could result in the collection removing it. we'd need to keep the visitor in-place initially,
-        // as if the container calls .get or anything in its visitContainer method, it would most likely want to
-        // get called if the service was unavailable / any new ones were added, etc.
-
         /**
          * Directly call the visitor's "visitContainer" method
          * to initialise it upon the given container.
@@ -122,8 +117,15 @@ export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor,
          * that any call to `visitContainer` means that the visitor was added
          * to a container.
          */
-        visitor.visitContainer?.(container);
-        return true;
+        const isAllowedToAttachVisitor = visitor.visitContainer?.(container);
+        
+        /**
+         * If a false-y return value was returned to signal that the visitor
+         * should not be attached to the given container, immediately remove it.
+         */
+        if (!isAllowedToAttachVisitor) {
+            this.removeVisitor(visitor);
+        }
     }
 
     /**

--- a/src/visitor-collection.class.ts
+++ b/src/visitor-collection.class.ts
@@ -1,167 +1,215 @@
-import { ContainerInstance } from "./container-instance.class";
-import { ServiceMetadata } from "./interfaces/service-metadata.interface";
-import { ContainerTreeVisitor, VisitRetrievalOptions } from "./interfaces/tree-visitor.interface";
-import { Disposable } from "./types/disposable.type";
-import { ServiceIdentifier } from "./types/service-identifier.type";
+import { ContainerInstance, defaultContainer } from './container-instance.class';
+import { ServiceMetadata } from './interfaces/service-metadata.interface';
+import { ContainerTreeVisitor, VisitRetrievalOptions } from './interfaces/tree-visitor.interface';
+import { Disposable } from './types/disposable.type';
+import { PartialPick } from './types/helper-types.type';
+import { ServiceIdentifier } from './types/service-identifier.type';
 
 /**
  * A collection of individual visitor objects, combined into a collection.
+ * This class implements the {@link ContainerTreeVisitor} interface
+ * (modulo {@link ContainerTreeVisitor.visitContainer}).
+ *
+ * When an event is dispatched upon the collection, all attached
+ * visitors will be notified in the order in which they were
+ * added to the collection.
  * @experimental
- * 
- * This interface implements everything but "visitContainer", as that
- * should never be done at random for all elements.
- * Instead, it is done in the "addVisitor" method.
- * 
- * The class is implemented in a semi-stateless fashion: it holds no
- * persistent references to any particular collection.
+ *
+ * @example
+ * ```ts
+ * const collection = new VisitorCollection();
+ *
+ * // Add our visitor to the collection.
+ * collection.addVisitor(new MyVisitor());
+ *
+ * // Dispatch an event onto the collection,
+ * // which will be broadcast to all attached visitors.
+ * collection.visitChildContainer(Container.ofChild('hello'));
+ * ```
  */
 export class VisitorCollection implements Disposable, Omit<ContainerTreeVisitor, 'visitContainer'> {
-    /** Whether the instance is disposed. */
-    public disposed = false;
+  /** Whether the instance is disposed. */
+  public disposed = false;
 
-    /** The visitors stored within the collection. */
-    protected visitors: ContainerTreeVisitor[] = [];
+  /** The visitors stored within the collection. */
+  protected visitors: ContainerTreeVisitor[] = [];
 
-    /**
-     * A flag stating whether any visitors are currently present in the collection.
-     * If not, all notifications will be ignored.
-     * 
-     * This is mostly for optimisation.
-     */
-    protected anyVisitorsPresent = false;
+  /**
+   * A flag stating whether any visitors are currently present in the collection.
+   * If not, all notifications will be ignored.
+   *
+   * This is mostly for optimisation.
+   */
+  protected anyVisitorsPresent = false;
 
-    /**
-     * A flag which states whether any visitors should be notified.
-     * If the collection has been disposed or no visitors are present,
-     * this evaluates to `false`.
-     */
-    protected get notifyVisitors () {
-        return !this.disposed && this.anyVisitorsPresent;
-    }
+  /**
+   * A flag which states whether any visitors should be notified.
+   * If the collection has been disposed or no visitors are present,
+   * this evaluates to `false`.
+   */
+  protected get notifyVisitors() {
+    return !this.disposed && this.anyVisitorsPresent;
+  }
 
-    constructor () { }
-
-    // the implementation below is very simple, there is definitely room for improvement.
-
-    /**
-     * Iterate the list of visitors, excluding any which have been disposed.
-     * Does not perform any iteration if no visitors are present.
-     * 
-     * @param callback A function to call for each visitor in the collection.
-     */
-    public forEach (callback: { (visitor: ContainerTreeVisitor ): void }) {
-        if (this.notifyVisitors) {
-            this.visitors.forEach(visitor => {
-                /** If the visitor has been disposed since the last iteration, free it from the store. */
-                if (visitor.disposed) {
-                    this.removeVisitor(visitor);
-                    return;
-                }
-
-                /** Disposed visitors should not be notified. */
-                callback(visitor);
-            });
-        }
-    }
-
-    visitChildContainer(child: ContainerInstance): void {
-        this.forEach(visitor => visitor.visitChildContainer?.(child));
-    }
-
-    visitOrphanedContainer(container: ContainerInstance): void {
-        this.forEach(visitor => visitor.visitOrphanedContainer?.(container));
-    }
-
-    visitNewService(serviceOptions: ServiceMetadata<unknown>): void {
-        this.forEach(visitor => visitor.visitNewService?.(serviceOptions));
-    }
-
-    visitUnavailableService(identifier: ServiceIdentifier, many: boolean): void {
-        this.forEach(visitor => visitor.visitUnavailableService?.(identifier, many));
-    }
-
-    visitRetrieval(identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void {
-        this.forEach(visitor => visitor.visitRetrieval?.(identifier, options));
-    }
-
-    /**
-     * Add a visitor to the collection.
-     * @experimental
-     * 
-     * @param visitor The visitor to append to the collection.
-     * @param container The container to initialise the container on.
-     */
-    addVisitor(visitor: ContainerTreeVisitor, container: ContainerInstance) {
-        /** If the visitor is already present, do not add another. */
-        if (this.visitors.includes(visitor)) {
-            return false;
+  /**
+   * Iterate the list of visitors, excluding any which have been disposed.
+   * Does not perform any iteration if no visitors are present.
+   *
+   * @param callback A function to call for each visitor in the collection.
+   */
+  public forEach(callback: { (visitor: ContainerTreeVisitor): void }) {
+    if (this.notifyVisitors) {
+      this.visitors.forEach(visitor => {
+        /** If the visitor has been disposed since the last iteration, free it from the store. */
+        if (visitor.disposed) {
+          this.removeVisitor(visitor);
+          return;
         }
 
-        this.visitors.push(visitor);
+        /** Disposed visitors should not be notified. */
+        callback(visitor);
+      });
+    }
+  }
 
-        /**
-         * Mark the collection as having visitors present, so
-         * it doesn't ignore any events passed to it.
-         */
-        if (!this.anyVisitorsPresent) {
-            this.anyVisitorsPresent = true;
-        }
+  visitChildContainer(child: ContainerInstance): void {
+    this.forEach(visitor => visitor.visitChildContainer?.(child));
+  }
 
-        /**
-         * Directly call the visitor's "visitContainer" method
-         * to initialise it upon the given container.
-         * 
-         * Implementation detail: We don't provide any sort of protection against 
-         * this being called again on a different container.
-         * The visitor would be able to handle that themselves, as the API states
-         * that any call to `visitContainer` means that the visitor was added
-         * to a container.
-         */
-        const isAllowedToAttachVisitor = visitor.visitContainer?.(container);
-        
-        /**
-         * If a false-y return value was returned to signal that the visitor
-         * should not be attached to the given container, immediately remove it.
-         */
-        if (!isAllowedToAttachVisitor) {
-            this.removeVisitor(visitor);
-        }
+  visitOrphanedContainer(container: ContainerInstance): void {
+    this.forEach(visitor => visitor.visitOrphanedContainer?.(container));
+  }
+
+  visitNewService(serviceOptions: ServiceMetadata<unknown>): void {
+    this.forEach(visitor => visitor.visitNewService?.(serviceOptions));
+  }
+
+  visitRetrieval(identifier: ServiceIdentifier<unknown>, options: VisitRetrievalOptions): void {
+    this.forEach(visitor => visitor.visitRetrieval?.(identifier, options));
+  }
+
+  /**
+   * Add a visitor to the collection.
+   * @experimental
+   *
+   * @param visitor The visitor to append to the collection.
+   * @param container The container to initialise the container on.
+   */
+  addVisitor(visitor: ContainerTreeVisitor, container: ContainerInstance) {
+    /** If the visitor is already present, do not add another. */
+    if (this.visitors.includes(visitor)) {
+      return false;
+    }
+
+    if ('visitOrphanedContainer' in visitor && container !== defaultContainer) {
+      /**
+       * Orphaned container events are only dispatched on the default container.
+       * Therefore, we need to create a proxy that forwards this event from the
+       * default container to this visitor.
+       */
+      VisitorCollection.forwardOrphanedContainerEvents(visitor);
+    }
+
+    this.visitors.push(visitor);
+
+    /**
+     * Mark the collection as having visitors present, so
+     * it doesn't ignore any events passed to it.
+     */
+    if (!this.anyVisitorsPresent) {
+      this.anyVisitorsPresent = true;
     }
 
     /**
-     * Remove a visitor from the collection,
-     * if it was already present.
-     * @experimental
-     * 
-     * @param visitor The visitor to remove from the collection.
+     * Directly call the visitor's "visitContainer" method
+     * to initialise it upon the given container.
+     *
+     * Implementation detail: We don't provide any sort of protection against
+     * this being called again on a different container.
+     * The visitor would be able to handle that themselves, as the API states
+     * that any call to `visitContainer` means that the visitor was added
+     * to a container.
      */
-    removeVisitor(visitor: ContainerTreeVisitor) {
-        const indexOfVisitor = this.visitors.indexOf(visitor);
+    const isAllowedToAttachVisitor = visitor.visitContainer?.(container);
 
-        if (indexOfVisitor === -1) {
-            return false;
-        }
-
-        /** Remove the element from the array via "splice". */
-        this.visitors.splice(indexOfVisitor, 1);
-
-        /** Re-evalute the length of the visitors array and recompute anyVisitorsPresent. */
-        if (this.visitors.length === 0) {
-            this.anyVisitorsPresent = false;
-        }
-
-        return true;
+    /**
+     * If a false-y return value was returned to signal that the visitor
+     * should not be attached to the given container, immediately remove it.
+     */
+    if (!isAllowedToAttachVisitor) {
+      this.removeVisitor(visitor);
+      return false;
     }
 
-    public dispose() {
-        /** Prevent duplicate calls to dispose. */
-        if (this.disposed) {
-            return;
-        }
+    return true;
+  }
 
+  /**
+   * Remove a visitor from the collection,
+   * if it was already present.
+   * @experimental
+   *
+   * @param visitor The visitor to remove from the collection.
+   */
+  removeVisitor(visitor: ContainerTreeVisitor) {
+    const indexOfVisitor = this.visitors.indexOf(visitor);
+
+    if (indexOfVisitor === -1) {
+      return false;
+    }
+
+    /** Remove the element from the array via "splice". */
+    this.visitors.splice(indexOfVisitor, 1);
+
+    /** Re-evalute the length of the visitors array and recompute anyVisitorsPresent. */
+    if (this.visitors.length === 0) {
+      this.anyVisitorsPresent = false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Forward any orphaned container events to the visitor
+   * through a proxy visitor attached to the default container.
+   *
+   * This is used when a visitor implements the {@link ContainerTreeVisitor.visitOrphanedContainer}
+   * handler, but the visitor was attached to a non-default container instance.
+   */
+  protected static forwardOrphanedContainerEvents(upstreamVisitor: ContainerTreeVisitor) {
+    const proxyVisitor: ContainerTreeVisitor = {
+      get disposed() {
+        return upstreamVisitor.disposed;
+      },
+
+      dispose() {
+        /** Should we forward the dispose upstream here? */
         this.disposed = true;
+      },
 
-        /** Notify all containers of disposal. */
-        this.forEach(visitor => visitor.dispose());
+      visitOrphanedContainer(container: ContainerInstance) {
+        if (!this.disposed) {
+          upstreamVisitor.visitOrphanedContainer?.(container);
+        }
+      },
+
+      visitContainer(container: ContainerInstance) {
+        return container === defaultContainer;
+      },
+    };
+
+    return defaultContainer.acceptTreeVisitor(proxyVisitor);
+  }
+
+  public dispose() {
+    /** Prevent duplicate calls to dispose. */
+    if (this.disposed) {
+      return;
     }
+
+    this.disposed = true;
+
+    /** Notify all containers of disposal. */
+    this.forEach(visitor => visitor.dispose());
+  }
 }

--- a/test/features/tree-visitor.spec.ts
+++ b/test/features/tree-visitor.spec.ts
@@ -1,0 +1,432 @@
+import {
+  Container,
+  ContainerInstance,
+  HostContainer,
+  ServiceIdentifier,
+  ServiceMetadata,
+  Token,
+} from '../../src/index';
+import { ContainerTreeVisitor, VisitRetrievalOptions } from '../../src/interfaces/tree-visitor.interface';
+import { ServiceIdentifierLocation } from '../../src/container-instance.class';
+
+describe('Tree Visitors', () => {
+  interface VisitorMock extends ContainerTreeVisitor {
+    disposed: boolean;
+    dispose: jest.Mock<void, [], VisitorMock>;
+    visitChildContainer: jest.Mock<void, [ContainerInstance], VisitorMock>;
+    visitOrphanedContainer: jest.Mock<void, [ContainerInstance], VisitorMock>;
+    visitNewService: jest.Mock<void, [ServiceMetadata<unknown>], VisitorMock>;
+    visitContainer: jest.Mock<boolean, [ContainerInstance], VisitorMock>;
+    visitRetrieval: jest.Mock<void, [ServiceIdentifier<unknown>, VisitRetrievalOptions], VisitorMock>;
+  }
+
+  /**
+   * Create a mock implementation of {@link ContainerTreeVisitor}.
+   *
+   * _Note: this does not call {@link ContainerInstance.acceptTreeVisitor}._
+   */
+  function createVisitorMock(): VisitorMock {
+    const visitor: VisitorMock = {
+      disposed: false,
+      dispose: jest.fn().mockImplementation(() => (visitor.disposed = true)),
+      visitChildContainer: jest.fn(),
+      visitOrphanedContainer: jest.fn(),
+      visitNewService: jest.fn(),
+      visitContainer: jest.fn().mockReturnValue(true),
+      visitRetrieval: jest.fn(),
+    };
+
+    return visitor;
+  }
+
+  function createAndSetupVisitorMock(container: ContainerInstance): VisitorMock {
+    const mock = createVisitorMock();
+    container.acceptTreeVisitor(mock);
+    return mock;
+  }
+
+  describe('Container.acceptTreeVisitor', () => {
+    it('is a function', () => {
+      expect(Container.acceptTreeVisitor).toBeInstanceOf(Function);
+    });
+  });
+
+  describe('Container.detachTreeVisitor', () => {
+    it('is a function', () => {
+      expect(Container.detachTreeVisitor).toBeInstanceOf(Function);
+    });
+  });
+
+  describe.each([
+    { name: 'Default Container', container: Container },
+    { name: 'Orphaned Container', container: ContainerInstance.of(Symbol(), null) },
+    { name: 'Child Container', container: Container.ofChild(Symbol()) },
+    /** Map each container to test each with a string and a Token. */
+  ])('$name: Tree Visitor API', ({ container }) => {
+    /** Clear the default container's visitors before each test. */
+    beforeEach(() => (Container['visitor']['visitors'] = []));
+
+    describe('visitChildContainer()', () => {
+      it('should be called with a reference to every child container', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        let newChild1 = container.ofChild(Symbol());
+        let newChild2 = container.ofChild(Symbol());
+
+        expect(visitor.dispose).not.toHaveBeenCalled();
+        expect(visitor.visitChildContainer).toHaveBeenCalledTimes(2);
+        expect(visitor.visitChildContainer).toHaveBeenNthCalledWith(1, newChild1);
+        expect(visitor.visitChildContainer).toHaveBeenNthCalledWith(2, newChild2);
+      });
+
+      it("shan't be called for orphaned containers", () => {
+        const visitor = createAndSetupVisitorMock(container);
+        let newOrphan = ContainerInstance.of(Symbol(), null);
+
+        expect(visitor.visitChildContainer).not.toHaveBeenCalledWith(newOrphan);
+        expect(visitor.visitContainer).not.toHaveBeenCalledWith(newOrphan);
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledTimes(1);
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledWith(newOrphan);
+      });
+
+      it("shan't be called for children of children", () => {
+        const visitor = createAndSetupVisitorMock(container);
+        let newChild = container.ofChild(Symbol());
+        let newChildOfChild = newChild.ofChild(Symbol());
+
+        expect(visitor.visitChildContainer).toHaveBeenCalledTimes(1);
+        expect(visitor.visitChildContainer).toHaveBeenCalledWith(newChild);
+        expect(visitor.visitChildContainer).not.toHaveBeenCalledWith(newChildOfChild);
+      });
+    });
+
+    describe('visitOrphanedContainer()', () => {
+      it('should be called for every orphaned container', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        let newOrphan = ContainerInstance.of(Symbol(), null);
+
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledTimes(1);
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledWith(newOrphan);
+      });
+
+      it("shan't be called for child containers", () => {
+        const visitor = createAndSetupVisitorMock(container);
+        let newChild = container.ofChild(Symbol());
+
+        expect(visitor.visitOrphanedContainer).not.toHaveBeenCalled();
+      });
+
+      it('will not be passed the default container', () => {
+        const visitor = createAndSetupVisitorMock(container);
+
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledTimes(0);
+        expect(visitor.visitOrphanedContainer).not.toHaveBeenCalledWith(ContainerInstance.defaultContainer);
+      });
+    });
+
+    describe('visitNewService()', () => {
+      it('should be called for every new service', () => {
+        const visitor = createAndSetupVisitorMock(container);
+
+        const serviceImpl = {
+          id: 'test-value',
+          value: 1,
+          dependencies: [],
+        };
+
+        container.set(serviceImpl);
+
+        expect(visitor.visitNewService).toHaveBeenCalledTimes(1);
+
+        /**
+         * Ensure the arguments are correct.
+         * We need to manually retrieve the arguments here so we can
+         * use Jest's matching feature.
+         */
+        const [firstCallArguments] = visitor.visitNewService.mock.calls;
+        expect(firstCallArguments).toMatchObject([serviceImpl]);
+      });
+
+      it('should be called for setValue', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        const token = new Token<string>();
+        const key = 'TEST_ABC';
+        const testValue = Symbol();
+
+        container.setValue(key, testValue);
+        container.setValue(token, testValue);
+
+        expect(visitor.visitNewService).toHaveBeenCalledTimes(2);
+
+        const [firstCallArguments, secondCallArguments] = visitor.visitNewService.mock.calls;
+        expect(firstCallArguments).toMatchObject([{ id: key, value: testValue, dependencies: [] }]);
+        expect(secondCallArguments).toMatchObject([{ id: token, value: testValue, dependencies: [] }]);
+      });
+
+      it('should only be called on the connected container', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        const token = new Token<string>();
+        const tokenChild = new Token<string>();
+        const testValue = 'TEST_ABC';
+
+        container.setValue(token, testValue);
+        const childContainer = container.ofChild(Symbol());
+        childContainer.setValue(tokenChild, testValue);
+
+        expect(visitor.visitNewService).toHaveBeenCalledTimes(1);
+
+        const [firstCallArguments] = visitor.visitNewService.mock.calls;
+        expect(firstCallArguments).toMatchObject([{ id: token, value: testValue, dependencies: [] }]);
+      });
+    });
+
+    describe('visitContainer()', () => {
+      it('should be called when the visitor is attached', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        expect(visitor.visitContainer).toHaveBeenCalledTimes(1);
+      });
+
+      it('should be called with the container the visitor was attached to', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        expect(visitor.visitContainer).toHaveBeenCalledWith(container);
+      });
+
+      it('should be able to unsubscribe from the container by returning false', () => {
+        /**
+         *  We use {@link createVisitorMock} here so we can tell
+         * {@link ContainerTreeVisitor.visitContainer} to return false.
+         */
+        const visitor = createVisitorMock();
+
+        visitor.visitContainer.mockReturnValue(false);
+
+        /**
+         * If the visitor was attached, the following methods
+         * would be called for these operations:
+         *   1. {@link ContainerTreeVisitor.visitNewService}
+         *   2. {@link ContainerTreeVisitor.visitChildContainer}
+         *   3. {@link ContainerTreeVisitor.visitRetrieval}
+         *   4. {@link ContainerTreeVisitor.visitOrphanedContainer}
+         */
+        container.setValue('test', 'value');
+        container.ofChild(Symbol());
+        container.get('test');
+        ContainerInstance.of(Symbol(), null);
+
+        expect(visitor.visitNewService).toHaveBeenCalledTimes(0);
+        expect(visitor.visitChildContainer).toHaveBeenCalledTimes(0);
+        expect(visitor.visitRetrieval).toHaveBeenCalledTimes(0);
+        expect(visitor.visitOrphanedContainer).toHaveBeenCalledTimes(0);
+      });
+
+      /**
+       * We skip the inverse case: visitors that return true are given events.
+       * This is because we already implicitly test this (numerous times) above.
+       */
+    });
+
+    describe('visitRetrieval()', () => {
+      it('should be called when a service is requested', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        const token = new Token<string>();
+        const value = 'TEST_ABC';
+
+        container.setValue(token, value);
+
+        /** We haven't requested any values yet, so it shouldn't have been called. */
+        expect(visitor.visitRetrieval).toHaveBeenCalledTimes(0);
+
+        container.get(token);
+        expect(visitor.visitRetrieval).toHaveBeenCalledTimes(1);
+        const [firstCallArguments] = visitor.visitRetrieval.mock.calls;
+
+        expect(firstCallArguments?.[0]).toMatchObject(token);
+      });
+
+      it('should be called even for unavailable services', () => {
+        const visitor = createAndSetupVisitorMock(container);
+        const unavailableToken = new Token<never>();
+
+        /** The operation throws, so we wrap it here. */
+        expect(() => container.get(unavailableToken)).toThrowError();
+        expect(visitor.visitRetrieval).toHaveBeenCalledTimes(1);
+
+        /** Now the same with {@link ContainerInstance.getOrNull}. */
+        container.getOrNull(unavailableToken);
+        expect(visitor.visitRetrieval).toHaveBeenCalledTimes(2);
+
+        const [firstCallArguments, secondCallArguments] = visitor.visitRetrieval.mock.calls;
+        expect(firstCallArguments?.[0]).toMatchObject(unavailableToken);
+        expect(secondCallArguments?.[0]).toMatchObject(unavailableToken);
+      });
+
+      describe('many: boolean', () => {
+        it('should be true if the service was requested via getMany[OrNull]', () => {
+          const visitor = createAndSetupVisitorMock(container);
+          const unavailableToken = new Token<never>();
+          const availableToken = new Token<string>();
+          const testValue = 'TEST_ABC';
+
+          container.set({ id: availableToken, value: testValue, multiple: true, dependencies: [] });
+
+          /** The operation throws, so we wrap it here. */
+          expect(() => container.getMany(unavailableToken)).toThrowError();
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(1);
+
+          /** Now the same with {@link ContainerInstance.getManyOrNull}, but with a valid identifier. */
+          container.getManyOrNull(availableToken);
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(2);
+
+          const [firstCallArguments, secondCallArguments] = visitor.visitRetrieval.mock.calls;
+          const expectedRetrievalOptions: Partial<VisitRetrievalOptions> = {
+            /** This is the default, so test that here. */
+            recursive: true,
+            many: true,
+          };
+
+          expect(firstCallArguments).toMatchObject([unavailableToken, expectedRetrievalOptions]);
+          expect(secondCallArguments).toMatchObject([availableToken, expectedRetrievalOptions]);
+        });
+
+        it('should be false if the service was requested via get[OrNull]', () => {
+          const visitor = createAndSetupVisitorMock(container);
+          const unavailableToken = new Token<never>();
+          const availableToken = new Token<string>();
+          const testValue = 'TEST_ABC';
+
+          container.setValue(availableToken, testValue);
+
+          /** The operation throws, so we wrap it here. */
+          expect(() => container.get(unavailableToken)).toThrowError();
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(1);
+
+          const [firstCallArguments] = visitor.visitRetrieval.mock.calls;
+          const expectedRetrievalOptions: Partial<VisitRetrievalOptions> = {
+            /** This is the default, so test that here. */
+            recursive: true,
+            many: false,
+          };
+
+          expect(firstCallArguments).toMatchObject([unavailableToken, expectedRetrievalOptions]);
+        });
+      });
+
+      describe('location: ServiceIdentifierLocation', () => {
+        it('should be None if the service was not found', () => {
+          const visitor = createAndSetupVisitorMock(container);
+          const unavailableToken = new Token<string>();
+
+          expect(() => container.getMany(unavailableToken, true)).toThrowError();
+          container.getManyOrNull(unavailableToken, false);
+
+          expect(() => container.get(unavailableToken, true)).toThrowError();
+          container.getOrNull(unavailableToken, false);
+
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(4);
+
+          const [firstCallArguments, secondCallArguments, thirdCallArguments, fourthCallArguments] =
+            visitor.visitRetrieval.mock.calls;
+
+          expect(firstCallArguments).toMatchObject([
+            unavailableToken,
+            {
+              recursive: true,
+              many: true,
+              location: ServiceIdentifierLocation.None,
+            },
+          ]);
+
+          expect(secondCallArguments).toMatchObject([
+            unavailableToken,
+            {
+              recursive: false,
+              many: true,
+              location: ServiceIdentifierLocation.None,
+            },
+          ]);
+
+          expect(thirdCallArguments).toMatchObject([
+            unavailableToken,
+            {
+              recursive: true,
+              many: false,
+              location: ServiceIdentifierLocation.None,
+            },
+          ]);
+
+          expect(fourthCallArguments).toMatchObject([
+            unavailableToken,
+            {
+              recursive: false,
+              many: false,
+              location: ServiceIdentifierLocation.None,
+            },
+          ]);
+        });
+
+        it('should be Local if the service was found locally', () => {
+          const visitor = createAndSetupVisitorMock(container);
+          const testToken = new Token<string>();
+          const testValue = 'TEST_ABC';
+
+          container.setValue(testToken, testValue);
+
+          container.get(testToken);
+          container.getOrNull(testToken);
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(2);
+
+          const [firstCallArguments, secondCallArguments] = visitor.visitRetrieval.mock.calls;
+
+          expect(firstCallArguments).toMatchObject([
+            testToken,
+            {
+              many: false,
+              recursive: true,
+              location: ServiceIdentifierLocation.Local,
+            },
+          ]);
+
+          expect(secondCallArguments).toMatchObject([
+            testToken,
+            {
+              many: false,
+              recursive: true,
+              location: ServiceIdentifierLocation.Local,
+            },
+          ]);
+        });
+
+        it('should be Parent if the service was found upstream', () => {
+          const childContainer = container.ofChild(Symbol());
+          const visitor = createAndSetupVisitorMock(childContainer);
+          const testToken = new Token<string>();
+          const testValue = 'TEST_ABC';
+
+          /** Set the value on the parent container. */
+          container.setValue(testToken, testValue);
+
+          childContainer.get(testToken, true);
+          expect(visitor.visitRetrieval).toHaveBeenCalledTimes(1);
+
+          const [firstCallArguments] = visitor.visitRetrieval.mock.calls;
+
+          /**
+           * Implementation Note
+           * ===================
+           *
+           * After this call, the token would now be considered as as a local identifier.
+           * Therefore, any subsequent calls for the same identifier would return
+           * {@link ServiceIdentifierLocation.Local}. This is intended behaviour.
+           */
+          expect(firstCallArguments).toMatchObject([
+            testToken,
+            {
+              many: false,
+              recursive: true,
+              location: ServiceIdentifierLocation.Parent,
+            },
+          ]);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add the first revision of the Visitor API to the container.
The API allows consumers to listen to certain
operations performed in the context of a container.
The implementation is decoupled from that of Containers.

Visitors are a play on the formal concept of the visitor pattern,
which is explained in abstract via the link below:
<https://en.wikipedia.org/wiki/Visitor_pattern>
Some inspiration was also taken from Dagger's SPI types.

This opens up the possibility of extending containers,
including the default, with custom functionality such as
reporting, diagnostics, error recovery and more.

Currently, the published API is deliberately minimal;
it implements a very small subset of functionality.
A good idea is to move slowly on this instead of rushing
the API design and regretting it later on.

As an example of the minimalistic design, some aspects
which were deliberately elided from this rendition include:
  - Allowing visitors to implement custom providers
Such functionality may not be appropriate in the context
of the Container, as it would introduce additional complexity
and a general uncertanty as to the location of metadata.

The API _definitely_ needs some form of revision.
It is not ready to be merged as-is.
No tests have been created yet due to the API most likely changing.
However, a basic structure has been put in place.

---

Fixes https://github.com/freshgum-bubbles/typedi/issues/11.