### PR TITLE
Fix GitHub Actions & Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,33 @@
 version: 2
+
+# Config reference:
+# <https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file>
 updates:
+  # Even though the package ecosystem is marked as NPM below,
+  # Dependabot still makes use of PNPM internally.
 - package-ecosystem: npm
   directory: "/"
   schedule:
-    interval: daily
-    time: "10:00"
-    timezone: Europe/Budapest
-  open-pull-requests-limit: 5
+    interval: weekly
+    time: "07:00"
+    # Use GMT as the timezone.
+    timezone: Europe/London
+  # Limit the open Dependabot pull requests to 2 so it
+  # doesn't blow up the Pull Requests page with individual
+  # dependency updates.
+  open-pull-requests-limit: 2
+  # For future maintainers: feel free to add yourselves here!
+  reviewers:
+    - freshgum-bubbles
   versioning-strategy: increase
   commit-message:
+    # This configuration renders commits as, for example:
+    #   build: bump @rollup/plugin-commonjs from 25.0.1 to 25.0.2
     prefix: build
+    # Make a separate prefix when upgrading "--save-dev" packages.
+    # This makes any errors that may occur as a result of a broken
+    # dependency easier to find in the commit timeline.
+    prefix-development: build(dev)
     include: scope
   ignore:
     - dependency-name: "husky"

--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -14,25 +14,7 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: https://registry.npmjs.org
-      # Set up PNPM so it doesn't write to the lockfile and installes devDependencies.
-      - uses: pnpm/action-setup@v2
-        with:
-          run_install: |
-            - args: [--frozen-lockfile, --save-dev]
-
-      # As instructed by: <https://github.com/pnpm/action-setup>
-      - name: Set PNPM Cache Directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
-        name: Restore PNPM Package Cache
-        with:
-          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+      - uses: ./.github/workflows/prepare-package-manager-workflow.yml
 
       # The rest of this scripts runs the various tasks.
       # - run: pnpm ci --ignore-scripts

--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -3,9 +3,10 @@ name: CD
 on:
   release:
     types: [created]
+
 jobs:
   publish:
-    name: Publish to NPM
+    name: Publish TypeDI to NPM
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -13,18 +14,42 @@ jobs:
         with:
           node-version: 'lts/*'
           registry-url: https://registry.npmjs.org
-      - run: npm ci --ignore-scripts
-      - run: npm run prettier:check
-      - run: npm run lint:check
-      - run: npm run test:ci
-      - run: npm run build:es2015
-      - run: npm run build:esm5
-      - run: npm run build:cjs
-      - run: npm run build:umd
-      - run: npm run build:types
+      # Set up PNPM so it doesn't write to the lockfile and installes devDependencies.
+      - uses: pnpm/action-setup@v2
+        with:
+          run_install: |
+            - args: [--frozen-lockfile, --save-dev]
+
+      # As instructed by: <https://github.com/pnpm/action-setup>
+      - name: Set PNPM Cache Directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Restore PNPM Package Cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      # The rest of this scripts runs the various tasks.
+      # - run: pnpm ci --ignore-scripts
+      - run: pnpm run prettier:check
+      - run: pnpm run lint:check
+      - run: pnpm run test:ci
+      - run: pnpm run build:es2015
+      - run: pnpm run build:esm5
+      - run: pnpm run build:cjs
+      - run: pnpm run build:umd
+      - run: pnpm run build:types
       - run: cp LICENSE build/LICENSE
       - run: cp README.md build/README.md
+      # Copy the package.json to the newly-created build folder, without devDependencies and scripts present.
       - run: jq 'del(.devDependencies) | del(.scripts)' package.json > build/package.json
-      - run: npm publish ./build
+      # Finally, publish the build to NPM.
+      - run: pnpm publish ./build
         env:
+          # Get this via NPM's webpage.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}

--- a/.github/workflows/lock-closed-issues-workflow.yml
+++ b/.github/workflows/lock-closed-issues-workflow.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 0 * * *'
 jobs:
   lock:
-    name: Lock closed issues
+    name: Lock Inactive Closed Issues
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/prepare-package-manager-workflow.yml
+++ b/.github/workflows/prepare-package-manager-workflow.yml
@@ -1,0 +1,22 @@
+name: Prepare Package Manager
+
+on:
+  workflow_call:
+  
+jobs:
+  pnpm_install:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Set PNPM Cache Directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Restore PNPM Package Cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
-  "name": "@freshgum/typedi",
+  "name": "@typed-inject/injector",
   "version": "0.2.0",
   "description": "Dependency injection for TypeScript.  Fork of TypeDI.",
   "author": "freshgum",
   "license": "MIT",
+  "private": false,
   "sideEffects": false,
   "main": "./cjs/index.js",
   "module": "./esm5/index.js",
@@ -37,7 +38,7 @@
     "test:coverage": "jest --coverage --verbose",
     "test:watch": "jest --watch",
     "test:ci": "jest --runInBand --coverage --verbose",
-    "prepublishOnly": "npm run build:cjs && npm run build:umd && build:types"
+    "prepublishOnly": "npm test && npm run build:cjs && npm run build:umd && build:types"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Fix the various GitHub Actions present in
the repository, which were copied over from
the original TypeDI repository.

This should also fix Dependabot.