### PR TITLE
Add HostContainer(), to allow services to get the executing container

### DIFF
--- a/src/constants/host-container.const.ts
+++ b/src/constants/host-container.const.ts
@@ -1,7 +1,8 @@
-import { Token } from "../token.class";
+import { ContainerInstance } from '../container-instance.class';
+import { Token } from '../token.class';
 
 /**
  * A special identifier which can be used to get the container
  * the service is currently being executed under.
  */
-export const HOST_CONTAINER = new Token('Host Container');
+export const HOST_CONTAINER = new Token<ContainerInstance>('Host Container');

--- a/src/constants/host-container.const.ts
+++ b/src/constants/host-container.const.ts
@@ -1,0 +1,7 @@
+import { Token } from "../token.class";
+
+/**
+ * A special identifier which can be used to get the container
+ * the service is currently being executed under.
+ */
+export const HOST_CONTAINER = new Token('Host Container');

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -50,6 +50,22 @@ interface ManyServicesMetadata {
 }
 
 /**
+ * A list of IDs which, when passed to `.has`, always return true.
+ * 
+ * This is used to facilitate the implementation of virtual tokens such as
+ * HostContainer which are not actually present in the container.
+ * 
+ * In these situations, returning `false` on a .has check would not be spec-compliant,
+ * and would expose internal implementation details regarding the container.
+ */
+const ALWAYS_RESOLVABLE: ServiceIdentifier[] = [
+  /**
+   * Provide compatibility with the `HostContainer()` API.
+   */
+  HOST_CONTAINER
+];
+
+/**
  * TypeDI can have multiple containers.
  * One container is ContainerInstance.
  */
@@ -109,6 +125,10 @@ export class ContainerInstance implements Disposable {
    */
   public has<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true): boolean {
     this[THROW_IF_DISPOSED]();
+
+    if (ALWAYS_RESOLVABLE.includes(identifier)) {
+      return true;
+    }
 
     const location = this.getIdentifierLocation(identifier);
 

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -51,10 +51,10 @@ interface ManyServicesMetadata {
 
 /**
  * A list of IDs which, when passed to `.has`, always return true.
- * 
+ *
  * This is used to facilitate the implementation of virtual tokens such as
  * HostContainer which are not actually present in the container.
- * 
+ *
  * In these situations, returning `false` on a .has check would not be spec-compliant,
  * and would expose internal implementation details regarding the container.
  */
@@ -62,7 +62,7 @@ const ALWAYS_RESOLVABLE: ServiceIdentifier[] = [
   /**
    * Provide compatibility with the `HostContainer()` API.
    */
-  HOST_CONTAINER
+  HOST_CONTAINER,
 ];
 
 /**

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -18,6 +18,7 @@ import { Resolvable } from './interfaces/resolvable.interface';
 import { wrapDependencyAsResolvable } from './utils/wrap-resolvable-dependency';
 import { ResolutionConstraintFlag } from './types/resolution-constraint.type';
 import { AnyServiceDependency } from './interfaces/service-options-dependency.interface';
+import { HOST_CONTAINER } from './constants/host-container.const';
 
 /**
  * A static variable containing "throwIfDisposed".
@@ -242,6 +243,13 @@ export class ContainerInstance implements Disposable {
    */
   public getOrNull<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true): T | null {
     this[THROW_IF_DISPOSED]();
+
+    /**
+     * Provide compatibility with the `HostContainer()` API.
+     */
+    if (identifier === HOST_CONTAINER) {
+      return this as unknown as T;
+    }
 
     const maybeResolvedMetadata = this.resolveMetadata(identifier, recursive);
 

--- a/src/functions/host-container.function.ts
+++ b/src/functions/host-container.function.ts
@@ -1,11 +1,11 @@
-import { HOST_CONTAINER } from "../constants/host-container.const";
+import { HOST_CONTAINER } from '../constants/host-container.const';
 
 /**
  * A special identifier which can be used to get the container
  * the service is currently being executed under.
  * Optionally, combined with resolution contraints such as SkipSelf,
  * this could be used to attain a reference to parent containers.
- * 
+ *
  * @example
  * An example of this can be found below:
  * ```ts
@@ -17,6 +17,6 @@ import { HOST_CONTAINER } from "../constants/host-container.const";
  * }
  * ```
  */
-export function HostContainer () {
-    return HOST_CONTAINER;
-} 
+export function HostContainer() {
+  return HOST_CONTAINER;
+}

--- a/src/functions/host-container.function.ts
+++ b/src/functions/host-container.function.ts
@@ -1,0 +1,22 @@
+import { HOST_CONTAINER } from "../constants/host-container.const";
+
+/**
+ * A special identifier which can be used to get the container
+ * the service is currently being executed under.
+ * Optionally, combined with resolution contraints such as SkipSelf,
+ * this could be used to attain a reference to parent containers.
+ * 
+ * @example
+ * An example of this can be found below:
+ * ```ts
+ * @Service([
+ *   HostContainer()
+ * ])
+ * export class MyService {
+ *   constructor (private container: ContainerInstance) { }
+ * }
+ * ```
+ */
+export function HostContainer () {
+    return HOST_CONTAINER;
+} 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from './error/cannot-instantiate-builtin-error';
 export * from './error/cannot-instantiate-value.error';
 export * from './error/service-not-found.error';
 
+export { HostContainer } from './functions/host-container.function';
 export { Lazy } from './functions/lazy.function';
 export { Many, Optional, Self, SkipSelf } from './functions/resolution-constraints.functions';
 

--- a/test/features/host-container.spec.ts
+++ b/test/features/host-container.spec.ts
@@ -1,0 +1,54 @@
+import { Container, HostContainer, Token, Service, ContainerInstance } from '../../src/index';
+
+describe('HostContainer', function () {
+  it('returns a token', function () {
+    expect(HostContainer()).toBeInstanceOf(Token);
+  });
+
+  it('has a constant return value with subsequent calls', function () {
+    for (let index = 0; index >= 10; index++) {
+      expect(HostContainer()).toStrictEqual(Container);
+    }
+  });
+
+  /**
+   * Just to be extra sure it resolves correctly in all situations,
+   * we make use of describe.each to run over it being used in three cases:
+   *   - The default container
+   *   - An orphaned container
+   *   - A child container
+   */
+  describe.each([
+    { name: 'Default Container', container: Container },
+    { name: 'Orphaned Container', container: ContainerInstance.of(Symbol(), null) },
+    { name: 'Child Container', container: Container.ofChild(Symbol()) },
+  ])('$name: HostContainer usage', ({ container }) => {
+    it('returns the host container', function () {
+      expect(container.get(HostContainer())).toStrictEqual(container);
+    });
+
+    it('always resolves', function () {
+      expect(container.has(HostContainer())).toStrictEqual(true);
+      expect(container.get(HostContainer())).toStrictEqual(container);
+    });
+
+    it('resolves as a service dependency', function () {
+      @Service({ container }, [HostContainer()])
+      class MyService {
+        constructor(public receivedValue: any) {}
+      }
+
+      const myService = container.get(MyService);
+      expect(myService.receivedValue).toStrictEqual(container);
+    });
+
+    it('returns true when passed to .has', function () {
+      expect(container.has(HostContainer())).toStrictEqual(true);
+    });
+
+    it('does not resolve in "many" functions', function () {
+      expect(() => container.getMany(HostContainer())).toThrowError();
+      expect(container.getManyOrNull(HostContainer())).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
Add support for a function which returns a Token.
The Token can then be used to get a reference to
the current container.

This is very useful as a drop-in replacement for the
previous API, which passed in the container as the
last argument to service constructors.

## Example

```ts
@Service([
  HostContainer()
])
export class MyService {
  constructor (private container: ContainerInstance) { }
}
```

Not tested yet.

Fixes https://github.com/freshgum-bubbles/typedi/issues/25.