### PR TITLE
Add a setValue method to ContainerInstance

### DIFF
--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -548,6 +548,21 @@ export class ContainerInstance implements Disposable {
   }
 
   /**
+   * Add a value to the container.
+   * 
+   * @param id The ID of the new value to set inside the container.
+   * Must be either a string or a Token.
+   * 
+   * @param value The value to set the ID to.
+   * 
+   * @returns The identifier of the given service in the container.
+   * This can then be passed to `.get` to resolve the identifier.
+   */
+  public setValue (id: string | Token<unknown>, value: unknown) {
+    return this.set({ id, value }, [ ]);
+  }
+
+  /**
    * Removes services with the given list of service identifiers.
    *
    * @param identifierOrIdentifierArray The list of service identifiers to remove from the container.

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -559,6 +559,10 @@ export class ContainerInstance implements Disposable {
    * This can then be passed to `.get` to resolve the identifier.
    */
   public setValue (id: string | Token<unknown>, value: unknown) {
+    if (typeof id !== 'string' && !(id instanceof Token)) {
+      throw new Error('The ID passed to setValue must either be a string or a Token.');
+    }
+    
     return this.set({ id, value }, [ ]);
   }
 

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -549,21 +549,21 @@ export class ContainerInstance implements Disposable {
 
   /**
    * Add a value to the container.
-   * 
+   *
    * @param id The ID of the new value to set inside the container.
    * Must be either a string or a Token.
-   * 
+   *
    * @param value The value to set the ID to.
-   * 
+   *
    * @returns The identifier of the given service in the container.
    * This can then be passed to `.get` to resolve the identifier.
    */
-  public setValue (id: string | Token<unknown>, value: unknown) {
+  public setValue(id: string | Token<unknown>, value: unknown) {
     if (typeof id !== 'string' && !(id instanceof Token)) {
       throw new Error('The ID passed to setValue must either be a string or a Token.');
     }
-    
-    return this.set({ id, value }, [ ]);
+
+    return this.set({ id, value }, []);
   }
 
   /**

--- a/test/features/set-value.spec.ts
+++ b/test/features/set-value.spec.ts
@@ -1,0 +1,49 @@
+import { Container, ContainerInstance, Token } from '../../src/index';
+
+describe('Container.setValue', function () {
+  /**
+   * == STOLEN FROM HOST-CONTAINER.SPEC.TS ==
+   * We again take a very thorough approach to ensuring all input / environment
+   * combinations result in consistent behaviour, and work correctly according to spec.
+   *
+   * Just to be extra sure it resolves correctly in all situations,
+   * we make use of describe.each to run over it being used in three cases:
+   *   - The default container
+   *   - An orphaned container
+   *   - A child container
+   */
+  describe.each(
+    [
+      { name: 'Default Container', container: Container },
+      { name: 'Orphaned Container', container: ContainerInstance.of(Symbol(), null) },
+      { name: 'Child Container', container: Container.ofChild(Symbol()) },
+      /** Map each container to test each with a string and a Token. */
+    ].flatMap(x => [
+      { ...x, id: 'test', idType: 'string' },
+      { ...x, id: new Token('test'), idType: 'Token' },
+    ])
+  )('$name: Container.setValue(<$idType>, ...)', ({ container, id }) => {
+    beforeEach(() => container.reset({ strategy: 'resetValue' }));
+
+    const expectedValue = Symbol();
+
+    it('should set a new value in the container', () => {
+      expect(() => container.setValue(id, expectedValue)).not.toThrowError();
+    });
+
+    it('should make .has return true for the ID', () => {
+      container.setValue(id, expectedValue);
+      expect(container.has(id)).toStrictEqual(true);
+    });
+
+    it('should then be retrievable via .get', () => {
+      container.setValue(id, expectedValue);
+      expect(container.get(id)).toStrictEqual(expectedValue);
+    });
+
+    it('should throw when passed a non-string/Token ID', () => {
+      // @ts-expect-error
+      expect(() => container.setValue(class {}, 'hello')).toThrowError();
+    });
+  });
+});


### PR DESCRIPTION
Add a shorthand for adding a value inside the
container that is either a string or a Token.

Previously, the following code was required to
set a value:

```ts
container.set({ id: token, value, dependencies: [ ] });
```

With the new API, it's:
```ts
container.setValue(token, value);
```