### PR TITLE
Add Boolean to built-ins list

### DIFF
--- a/src/constants/builtins.const.ts
+++ b/src/constants/builtins.const.ts
@@ -1,1 +1,1 @@
-export const BUILT_INS = [String, Object, Symbol, Array, Number];
+export const BUILT_INS = [String, Object, Boolean, Symbol, Array, Number];

--- a/test/decorators/Service.spec.ts
+++ b/test/decorators/Service.spec.ts
@@ -253,7 +253,7 @@ describe('Service Decorator', function () {
   });
 
   describe('Protection against built-in types', () => {
-    const builtinTypes = [String, Object, Symbol, Array, Number];
+    const builtinTypes = [String, Object, Symbol, Array, Number, Boolean];
 
     describe.each(builtinTypes.map(type => ({ type, name: type.name })))('$name() usage', ({ type: builtinType }) => {
       it('throws if used and no factory is provided', () => {


### PR DESCRIPTION
Boolean should also be usable as a built-in type.
Therefore, we add support for it to the Container
and Service decorators.