### PR TITLE
Add ExtractToken type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export { ServiceOptions } from './interfaces/service-options.interface';
 export { Constructable } from './types/constructable.type';
 export { ContainerIdentifier } from './types/container-identifier.type';
 export { ContainerScope } from './types/container-scope.type';
+export { ExtractToken } from './types/extract-token.type';
 export { ServiceIdentifier } from './types/service-identifier.type';
 export { LazyReference } from './types/lazy-reference.type';
 export { ResolutionConstraintFlag, ResolutionConstraintsDescriptor } from './types/resolution-constraint.type';

--- a/src/types/extract-token.type.ts
+++ b/src/types/extract-token.type.ts
@@ -1,0 +1,13 @@
+import { Token } from "../token.class";
+
+/**
+ * Extract the type of a Token.
+ * 
+ * @example
+ * ```ts
+ * const token = new Token<string>();
+ * const value: ExtractToken<typeof token> = "Hello!";
+ * ```
+ * 
+ */
+export type ExtractToken<T> = T extends Token<infer U> ? U : never;


### PR DESCRIPTION
Add ExtractToken type:

```ts
import { ExtractToken, Token } from '@typed-inject/injector';

interface A {
  value: 2;
}

type AToken = Token<A>;

const token: AToken = new Token<A>();
const value: ExtractToken<AToken> = { value: 2 };
```