### PR TITLE
Container creation strategies

### DIFF
--- a/src/interfaces/create-container-options.interface.ts
+++ b/src/interfaces/create-container-options.interface.ts
@@ -1,0 +1,182 @@
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ContainerInstance } from "../container-instance.class";
+
+/**
+ * @fileoverview
+ * This file contains an interface for describing how the overall
+ * container creation process should work.
+ * 
+ * Containers are created through three methods:
+ *   - {@link ContainerInstance.(of:static)}
+ *   - {@link ContainerInstance.of}
+ *   - {@link ContainerInstance.ofChild}
+ * 
+ * In each, we don't currently have a way to describe
+ * what to do if a container with the specified name already exists.
+ * Consider the following example:
+ * ```ts
+ * ContainerInstance.of('my-container', null);
+ * defaultContainer.ofChild('my-container');
+ * ```
+ * 
+ * In 0.3.22, the {@link ContainerInstance.ofChild} call actually
+ * returns the instance of the *orphaned container*.
+ * 
+ * This is *really* bad, as it means that, unless you use unique
+ * symbols as container IDs, operations which you would *expect*
+ * to work may fail in very unexpected ways.
+ * 
+ * This is also present in other methods, such as {@link ContainerInstance.of}
+ * and its static equivalent.
+ * 
+ * If we look [upstream](https://github.com/typestack/typedi), 
+ * the "container inheritance rework" which sadly never emerged 
+ * suggested allowing a set of options to supplement the default
+ * container creation behaviour.  One of those options was to
+ * throw in the event of a container already existing.
+ * 
+ * This isn't a suitable default either, as you'd have to carry
+ * around references to your container everywhere.
+ * Consider the following:
+ * ```ts
+ * defaultContainer.ofChild('known-name'); // works
+ * defaultContainer.ofChild('known-name'); // fails
+ * ```
+ * Above, we're essentially utilising the container as a map of maps.
+ * This is very convenient, as it means that we can essentially say:
+ * "'Create' this, but I *know* it already exists."
+ * 
+ * In this case, I'd say that the default behaviour doesn't do either.
+ * For instance, wouldn't you want to be able to tell it to fail if 
+ * a container with that name *doesn't* exist? Perhaps your application
+ * expects it to be created by central configuration code. In that
+ * case, you'd definitely want it to fail.
+ * 
+ * To hack a fix for the above, you *could* check {@link ContainerRegistry}
+ * before every call to `ofChild`, but that seems hacky.
+ * We can do better!
+ * 
+ * So, to remedy the above, we're introducing container creation options.
+ * This is done through {@link CreateContainerOptions}.
+ * These can be passed to any of the 3 methods above (of, of & ofChild).
+ * 
+ * They don't change any of the resolution logic inside, e.g. 
+ * {@link ContainerInstance.get} like the upstream implementation did, 
+ * but they give a *lot* more control over how TypeDI deals with certain situations
+ * around when to create a container, and when not to.
+ * 
+ * ## Implementation Note
+ * In future, we may want to extend this to allow describing how the
+ * container should resolve symbols.
+ */
+
+/**
+ * A description of how TypeDI should react when a container
+ * with the specified ID already exists in the registry.
+ * 
+ * There are three possible values:
+ *   - `throw`: Throw an error upon conflict.
+ *   - `null`: Return null.
+ *   - `returnExisting`: Return the existing container.
+ * 
+ * **If you pass a {@link ContainerConflictDefinition} without this,
+ * it will default to `throw`.  Otherwise, `returnExisting` is the default.**
+ * 
+ * @example
+ * Review the following:
+ * ```ts
+ * ContainerInstance.of('my-container', defaultContainer, {
+ *   onConflict: 'throw'
+ * });
+ * ```
+ * 
+ * @remarks
+ * Be aware that when `returnExisting` is used, you may encounter
+ * unexpected errors if containers with completely different configurations
+ * have the same ID. Therefore, it is discouraged in most situations.
+ * *However, for historical reasons, it remains the default.*
+ * 
+ * Consider the following example:
+ * ```ts
+ * ContainerInstance.of('my-container', null); // Create an orphaned container.
+ * defaultContainer.ofChild('my-container'); // Create a child container.
+ * ```
+ * In the case of `returnExisting`, the call to {@link ContainerInstance.ofChild} 
+ * would return a reference to the orphaned container, which will cause unexpected
+ * runtime errors when your code is unable to resolve symbols from the parent container.
+ * 
+ * As such, when `returnExisting` is utilised, it is heavily recommended to use
+ * unique symbol IDs that are unique to a certain part of your application.
+ */
+export type ContainerConflictStrategy = 
+    | 'throw' 
+    | 'null' 
+    | 'returnExisting';
+
+/**
+ * A description of how TypeDI should react when a container
+ * with the specified ID does not already exist in the registry.
+ * 
+ * There are three possible values:
+ *   - `throw`: Throw an error.
+ *   - `null`: Return null.
+ *   - `returnNew`: Return a newly-created container instance. **This is the default.**
+ * 
+ * @example
+ * Here is an example:
+ * ```ts
+ * // When the container doesn't already exist...
+ * assert(defaultContainer.ofChild(Symbol('my-unique-id'), { onFree: 'null' }) === null);
+ * 
+ * // We can also 'returnNew' to use the default behaviour.
+ * defaultContainer.ofChild(Symbol(), { onFree: 'returnNew' });
+ * 
+ * // Or, we can throw if the container *should* already exist.
+ * defaultContainer.ofChild(Symbol(), { onFree: 'throw' }); // Throws an error.
+ * ```
+ */
+export type ContainerFreeStrategy =
+    | 'throw'
+    | 'null'
+    | 'returnNew';
+
+/**
+ * A definition of what constitutes a conflict in the case of a pre-existing container
+ * with the same ID as the one passed to a container creation method.
+ * 
+ * There are two possible values:
+ *   - `rejectAll`: If a container already exists, immediately reject it. **This is the default.**
+ *   - `allowSameParent`: Allow a container if it has the same parent as the one provided.
+ */
+export type ContainerConflictDefinition =
+    | 'rejectAll'
+    | 'allowSameParent';
+
+/**
+ * A set of options to supplement the container creation process.
+ */
+export interface CreateContainerOptions {
+    /**
+     * A description of how TypeDI should react when a container
+     * with the specified ID already exists in the registry.
+     * 
+     * @see {@link ContainerConflictStrategy}
+     */
+    onConflict?: ContainerConflictStrategy;
+
+    /**
+     * A description of how TypeDI should react when a container
+     * with the specified ID does not already exist in the registry.
+     * 
+     * @see {@link ContainerFreeStrategy}
+     */
+    onFree?: ContainerFreeStrategy;
+
+    /**
+     * A description of what constitutes a conflict in the case of a pre-existing container
+     * with the same ID as the one passed to a container creation method.
+     * 
+     * @see {@link ContainerConflictDefinition}
+     */
+    conflictDefinition?: ContainerConflictDefinition;    
+}

--- a/src/types/create-container-result.type.ts
+++ b/src/types/create-container-result.type.ts
@@ -1,0 +1,7 @@
+import { ContainerInstance } from "../container-instance.class";
+import { CreateContainerOptions } from "../interfaces/create-container-options.interface";
+
+export type CreateContainerResult<T extends CreateContainerOptions> =
+    T['onConflict'] extends 'null' ? null | ContainerInstance :
+    T['onFree'] extends 'null' ? null | ContainerInstance :
+    ContainerInstance;

--- a/test/features/create-options.spec.ts
+++ b/test/features/create-options.spec.ts
@@ -1,0 +1,125 @@
+import { Container, HostContainer, Token, Service, ContainerInstance } from '../../src/index';
+import { defaultContainer } from '../../src/container-instance.class';
+import { ContainerConflictDefinition } from '../../src/interfaces/create-container-options.interface';
+
+const getID = () => Symbol('test');
+
+describe('Container creation options', () => {
+  it('should reject all conflicts if "rejectAll" is set as the conflict definition', () => {
+    const id = getID();
+
+    ContainerInstance.of(id, null);
+
+    expect(() => {
+      defaultContainer.ofChild(id, { onConflict: 'throw' });
+    }).toThrow();
+  });
+
+  it('should allow conflicts if "allowSameParent" is set and the parents match', () => {
+    const id = getID();
+    let container1 = defaultContainer.ofChild(id);
+    let container2!: ContainerInstance;
+
+    expect(() => {
+      container2 = defaultContainer.ofChild(id, { conflictDefinition: 'allowSameParent' });
+    }).not.toThrow();
+
+    expect(container1).toStrictEqual(container2);
+  });
+
+  it('should not fail if options are set and a container does not already exist', () => {
+    const id = getID();
+
+    expect(() => {
+      defaultContainer.ofChild(id, {
+        onConflict: 'throw',
+        conflictDefinition: 'rejectAll',
+      });
+    }).not.toThrow();
+  });
+
+  it.each([{ conflictDefinition: 'allowSameParent' }, { conflictDefinition: 'rejectAll' }])(
+    'should throw if definition is set to "$conflictDefinition" without a strategy and there is a conflict',
+    ({ conflictDefinition }) => {
+      const id = getID();
+
+      expect(() => {
+        defaultContainer.of(id);
+        ContainerInstance.of(id, null, { conflictDefinition: conflictDefinition as ContainerConflictDefinition });
+      }).toThrow();
+    }
+  );
+
+  it('should throw if "allowSameParent" is set and the parents do not match', () => {
+    const id = getID();
+
+    expect(() => {
+        defaultContainer.of(id);
+        ContainerInstance.of(id, null, { conflictDefinition: 'allowSameParent' });
+    }).toThrow();
+  });
+
+  it('should not throw if a container does not already exist', () => {
+    const id = getID();
+
+    expect(() => {
+        defaultContainer.of(id, { onConflict: 'throw' });
+    }).not.toThrow();
+  });
+
+  it('should allow conflicts by default', () => {
+    const id = getID();
+
+    expect(() => {
+      ContainerInstance.of(id, null);
+      defaultContainer.ofChild(id);
+    }).not.toThrow();
+  });
+
+  it('should allow conflicts if "returnExisting" is passed', () => {
+    const id = getID();
+
+    expect(() => {
+        // todo: add more expect()s here
+        ContainerInstance.of(id, null);
+        defaultContainer.ofChild(id, { onConflict: 'returnExisting' });
+    }).not.toThrow();
+  });
+
+  it('should return null if a conflict arises and strategy is "null"', () => {
+    const id = getID();
+
+    ContainerInstance.of(id, null);
+    expect(defaultContainer.ofChild(id, { onConflict: 'null' })).toBeNull();
+  });
+
+  it('should not return null if the strategy is null and a container does not already exist', () => {
+    const id = getID();
+    const child = defaultContainer.ofChild(id, { onConflict: 'null' });
+
+    expect(child).not.toBeNull();
+    expect(child!.id).toStrictEqual(id);
+    expect(child).toBeInstanceOf(ContainerInstance);
+  });
+
+  describe('onFree', () => {
+    it('should throw if set to "throw" and a container with the ID does not exist', () => {
+        const id = getID();
+        expect(() => defaultContainer.of(id, { onFree: 'throw' })).toThrow();
+    });
+
+    it('should return null if set to "null" and a container with the ID does not exist', () => {
+        const id = getID();
+        expect(defaultContainer.of(id, { onFree: 'null' })).toBeNull();
+    });
+
+    it('should use default behaviour if set to "returnNew"', () => {
+        const id = getID();
+        const child = defaultContainer.of(id, { onFree: 'returnNew' });
+        
+        expect(child).not.toBeNull();
+        expect(child.id).toStrictEqual(id);
+        expect(child).toBeInstanceOf(ContainerInstance);
+    });
+  });
+});


### PR DESCRIPTION
These are a set of options which tell TypeDI
how to handle conflicting containers.
For instance, if a child container is created with
the ID "my-container", and then an ofChild
call is made with the same ID, the pre-existing
container will be returned.

This has a lot of downsides, many of which
are documented in the create options file:

https://github.com/freshgum-bubbles/typedi/blob/c5c4eb7d09cb6d30041d9779ea5a770b312993b4/src/interfaces/create-container-options.interface.ts#L4-L71C1

(In fact, I'd almost call this a fix instead of feat.)

The new API doesn't interfere with TypeDI's
default behaviour of allowing conflicts.
Therefore, this isn't a breaking change.