### PR TITLE
Remove requirement for dependencies when "type" is not passed to Container.set

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -32,7 +32,7 @@ const PROPERTIES_TO_MANGLE = [
 ];
 
 /** @type {import('@rollup/plugin-terser').Options} */
-const terserOptions = {
+const TERSER_OPTIONS = {
   compress: {
     defaults: true,
     keep_fargs: false,
@@ -52,7 +52,7 @@ const terserOptions = {
 };
 
 /** @type {import('@rollup/plugin-terser').Options} */
-const mjsTerserOptions = mergeObjects(terserOptions, {
+const MJS_TERSER_OPTIONS = mergeObjects(TERSER_OPTIONS, {
   compress: {
     module: true
   }  
@@ -72,7 +72,7 @@ export default {
       format: 'umd',
       file: 'build/bundles/typedi.umd.min.js',
       sourcemap: true,
-      plugins: [terser(terserOptions)],
+      plugins: [terser(TERSER_OPTIONS)],
     },
     {
       format: 'es',
@@ -83,7 +83,7 @@ export default {
       format: 'es',
       file: 'build/bundles/typedi.min.mjs',
       sourcemap: true,
-      plugins: [terser(mjsTerserOptions)],
+      plugins: [terser(MJS_TERSER_OPTIONS)],
     }
   ],
   plugins: [commonjs(), nodeResolve()],

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -52,6 +52,21 @@ const TERSER_OPTIONS = {
 };
 
 /** 
+ * @type {Partial<import('rollup').OutputOptions>} 
+ * A partial set of options for all Rollup output declarations.
+ */
+const DEFAULT_ROLLUP_OUTPUT_OPTIONS = {
+  sourcemap: true
+};
+
+/**
+ * @param {import('rollup').OutputOptions} options The options to merge with defaults.
+ */
+function createOutput (options) {
+  return mergeObjects(DEFAULT_ROLLUP_OUTPUT_OPTIONS, options);
+}
+
+/** 
  * @type {import('@rollup/plugin-terser').Options} 
  * A set of Terser options for ES6 builds of TypeDI.
  */
@@ -68,26 +83,22 @@ export default {
       name: 'TypeDI',
       format: 'umd',
       file: 'build/bundles/typedi.umd.js',
-      sourcemap: true,
     },
     {
       name: 'TypeDI',
       format: 'umd',
       file: 'build/bundles/typedi.umd.min.js',
-      sourcemap: true,
       plugins: [terser(TERSER_OPTIONS)],
     },
     {
       format: 'es',
       file: 'build/bundles/typedi.mjs',
-      sourcemap: true,
     },
     {
       format: 'es',
       file: 'build/bundles/typedi.min.mjs',
-      sourcemap: true,
       plugins: [terser(MJS_TERSER_OPTIONS)],
-    }
-  ],
+    },
+  ].map(createOutput),
   plugins: [commonjs(), nodeResolve()],
 };

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -51,7 +51,10 @@ const TERSER_OPTIONS = {
   }
 };
 
-/** @type {import('@rollup/plugin-terser').Options} */
+/** 
+ * @type {import('@rollup/plugin-terser').Options} 
+ * A set of Terser options for ES6 builds of TypeDI.
+ */
 const MJS_TERSER_OPTIONS = mergeObjects(TERSER_OPTIONS, {
   compress: {
     module: true

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -5,7 +5,7 @@ import { Token } from './token.class';
 import { Constructable } from './types/constructable.type';
 import { ServiceIdentifier } from './types/service-identifier.type';
 import { ServiceMetadata } from './interfaces/service-metadata.interface';
-import { ServiceOptions, ServiceOptionsWithDependencies } from './interfaces/service-options.interface';
+import { ServiceOptions, ServiceOptionsWithDependencies, ServiceOptionsWithoutTypeOrDependencies } from './interfaces/service-options.interface';
 import { EMPTY_VALUE } from './constants/empty.const';
 import { ContainerIdentifier } from './types/container-identifier.type';
 import { ContainerScope } from './types/container-scope.type';
@@ -638,6 +638,36 @@ export class ContainerInstance implements Disposable {
    *   - `"object"`: This could be a {@link Token} or anything else.
    */
   public set<T = unknown>(serviceOptions: ServiceOptionsWithDependencies<T>): ServiceIdentifier;
+
+  /**
+   * Add a service to the container, without providing any dependencies which would
+   * normally be required when initialising a service with a class-based {@link ServiceOptions.type | .type} member.
+   * 
+   * @param serviceOptions The options for the service to add to the container.
+   * These options are expected to omit both the {@link ServiceOptions.type | .type}
+   * and {@link ServiceOptions.dependencies | .dependencies} members.
+   *
+   * @returns The identifier of the given service in the container.
+   * This can then be passed to {@link ContainerInstance.get | .get} to resolve the identifier.
+   *
+   * @throws Error
+   * This exception is thrown if the container has been disposed.
+   *
+   * @throws {@link CannotInstantiateBuiltInError}
+   * This exception is thrown if the service references a built-in type,
+   * such as Number or String, without an accompanying factory.
+   * These are considered invalid, as the container has no way to instantiate them.
+   *
+   * @throws {@link CannotInstantiateValueError}
+   * This exception is thrown if a dependency of the service cannot be instantiated.
+   * A `typeof` check on a dependency should always result in one of the following:
+   *   - `"function"`: This would be for class or function-based services.
+   *   - `"string"`: Though discouraged, a string {@link ServiceIdentifier} can
+   *     be used to reference a given dependency in the container.
+   *   - `"object"`: This could be a {@link Token} or anything else.
+   */
+  public set<T = unknown>(serviceOptions: ServiceOptionsWithoutTypeOrDependencies<T>): ServiceIdentifier;
+
   public set<T = unknown>(
     serviceOptions: ServiceOptions<T> | Omit<ServiceOptions<T>, 'dependencies'>,
     precompiledDependencies?: Resolvable[]

--- a/src/container-instance.class.ts
+++ b/src/container-instance.class.ts
@@ -5,7 +5,11 @@ import { Token } from './token.class';
 import { Constructable } from './types/constructable.type';
 import { ServiceIdentifier } from './types/service-identifier.type';
 import { ServiceMetadata } from './interfaces/service-metadata.interface';
-import { ServiceOptions, ServiceOptionsWithDependencies, ServiceOptionsWithoutTypeOrDependencies } from './interfaces/service-options.interface';
+import {
+  ServiceOptions,
+  ServiceOptionsWithDependencies,
+  ServiceOptionsWithoutTypeOrDependencies,
+} from './interfaces/service-options.interface';
 import { EMPTY_VALUE } from './constants/empty.const';
 import { ContainerIdentifier } from './types/container-identifier.type';
 import { ContainerScope } from './types/container-scope.type';
@@ -642,7 +646,7 @@ export class ContainerInstance implements Disposable {
   /**
    * Add a service to the container, without providing any dependencies which would
    * normally be required when initialising a service with a class-based {@link ServiceOptions.type | .type} member.
-   * 
+   *
    * @param serviceOptions The options for the service to add to the container.
    * These options are expected to omit both the {@link ServiceOptions.type | .type}
    * and {@link ServiceOptions.dependencies | .dependencies} members.

--- a/src/interfaces/service-options.interface.ts
+++ b/src/interfaces/service-options.interface.ts
@@ -21,7 +21,7 @@ export type ServiceOptionsWithoutDependencies<T = unknown> = Omit<ServiceOptions
  * A variant of {@link ServiceOptions} which does not contain either a class-based type member,
  * or a "dependencies" member.  This is used to make the declaration of static values easier.
  * @internal
- * 
+ *
  * @see {@link Container.set}
  */
 export type ServiceOptionsWithoutTypeOrDependencies<T = unknown> = Omit<ServiceOptions<T>, 'type' | 'dependencies'>;

--- a/src/interfaces/service-options.interface.ts
+++ b/src/interfaces/service-options.interface.ts
@@ -16,3 +16,12 @@ export type ServiceOptions<T = unknown> = Partial<RequireExactlyOne<ServiceMetad
 export type ServiceOptionsWithDependencies<T = unknown> = ServiceOptions<T> &
   SetRequired<ServiceOptions<T>, 'dependencies'>;
 export type ServiceOptionsWithoutDependencies<T = unknown> = Omit<ServiceOptions<T>, 'dependencies'>;
+
+/**
+ * A variant of {@link ServiceOptions} which does not contain either a class-based type member,
+ * or a "dependencies" member.  This is used to make the declaration of static values easier.
+ * @internal
+ * 
+ * @see {@link Container.set}
+ */
+export type ServiceOptionsWithoutTypeOrDependencies<T = unknown> = Omit<ServiceOptions<T>, 'type' | 'dependencies'>;

--- a/test/features/service-options-without-dependencies.spec.ts
+++ b/test/features/service-options-without-dependencies.spec.ts
@@ -1,0 +1,14 @@
+import {
+    Container,
+    Token,
+} from '../../src/index';
+
+describe('Container.set without dependencies', () => {
+    it('should provide the appropriate overload and function correctly', () => {
+        const NAME = new Token<string>();
+
+        Container.set({ id: NAME, value: 'Joanna' });
+        expect(Container.has(NAME)).toBe(true);
+        expect(Container.get(NAME)).toStrictEqual('Joanna');
+    });
+});

--- a/test/features/service-options-without-dependencies.spec.ts
+++ b/test/features/service-options-without-dependencies.spec.ts
@@ -1,14 +1,11 @@
-import {
-    Container,
-    Token,
-} from '../../src/index';
+import { Container, Token } from '../../src/index';
 
 describe('Container.set without dependencies', () => {
-    it('should provide the appropriate overload and function correctly', () => {
-        const NAME = new Token<string>();
+  it('should provide the appropriate overload and function correctly', () => {
+    const NAME = new Token<string>();
 
-        Container.set({ id: NAME, value: 'Joanna' });
-        expect(Container.has(NAME)).toBe(true);
-        expect(Container.get(NAME)).toStrictEqual('Joanna');
-    });
+    Container.set({ id: NAME, value: 'Joanna' });
+    expect(Container.has(NAME)).toBe(true);
+    expect(Container.get(NAME)).toStrictEqual('Joanna');
+  });
 });


### PR DESCRIPTION
This change removes the requirement that *all* 1-param calls to `Container.set` must pass an object
with a "dependencies" member.  In many cases, such as when declaring a value, this is unwanted, as
you then have to pointlessly declare `dependencies: []`, even though `{ value: 'Joanna' }` will obviously
never have any injectable dependencies.

Therefore, this change adds an additional overload to the `Container.set` method, which elides this behaviour.