### PR TITLE
Symbolic Service Disposal

### DIFF
--- a/src/constants/dispose.const.mts
+++ b/src/constants/dispose.const.mts
@@ -1,0 +1,1 @@
+export const DISPOSE = Symbol('dispose');

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1629,7 +1629,7 @@ export class ContainerInstance implements Disposable {
       (value as ObjectWithDisposeMethod).dispose
     );
 
-    if (disposeMethod && shouldResetValue) {
+    if (disposeMethod) {
       /** We make sure to set `this` to the value to prevent breakages. */
       return disposeMethod.call(value);
     }

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1573,6 +1573,14 @@ export class ContainerInstance implements Disposable {
      *   4. For backwards compatibility, we maintain support for an ordinary dispose method.
      *      However, this remnant is not ideal, as it may result in unexpected behaviour.
      * 
+     * For the uninitiated, both {@link Symbol.dispose} and {@link Symbol.asyncDispose}
+     * are parts of the newly-created (as of 2023) Explicit Resource Management proposal:
+     * <https://tc39.es/proposal-explicit-resource-management/>.
+     * 
+     * As a result, we ensure that they exist in the environment before checking for
+     * their existence on the target value.  If the checks below did not exist, if
+     * `Symbol.dispose` evaluated to `undefined`, we would be searching for an 
+     * `undefined` property on the target value, which is unwanted behaviour.
      * 
      * One important distinction from the previous behaviour, however, is that this
      * method no longer swallows promises from calls to a service's disposal method.
@@ -1592,6 +1600,8 @@ export class ContainerInstance implements Disposable {
       (value as ObjectWithDISymbolDispose)[DISPOSE] ?? 
       (value as ObjectWithSymbolDispose)[Symbol.dispose] ?? 
       (value as ObjectWithSymbolAsyncDispose)[Symbol.asyncDispose] ?? 
+      (Symbol.dispose && (value as ObjectWithSymbolDispose)[Symbol.dispose]) ?? 
+      (Symbol.asyncDispose && (value as ObjectWithSymbolAsyncDispose)[Symbol.asyncDispose]) ?? 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       (value as ObjectWithDisposeMethod).dispose
     );

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1577,7 +1577,6 @@ export class ContainerInstance implements Disposable {
 
   /**
    * Check if the given service is able to be destroyed and, if so, destroys it in-place.
-   * @deprecated
    *
    * @remarks
    * If the service contains a method named `destroy`, it is called.

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1583,7 +1583,7 @@ export class ContainerInstance implements Disposable {
      */
     const shouldResetValue = force || !!type || !!factory;
 
-    if (typeof value !== 'object' || value === null || !shouldResetValue) {
+    if (!shouldResetValue || typeof value !== 'object' || value === null) {
       return;
     }
 

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1625,54 +1625,20 @@ export class ContainerInstance implements Disposable {
   /**
    * Create a function which disposes the provided object, if it hosts a
    * suitable method for object disposal.
-   * 
+   *
    * @param subject The subject of the disposal operation.
-   * 
-   * @returns A function which will dispose the provided object.
-   * 
-   * @remarks
-   * The return type of the returned function depends upon the declared disposal method.
-   * If {@link Symbol.asyncDispose} is declared, it is more than likely that a {@link Promise} will be returned.
-   * Note that if a disposal method does not exist, void is returned.
+   *
+   * @returns The returned value of the object's disposal method.
    */
   private invokeDisposal (subject: object) {
-    /**
-     * In order of priority, we check for the existence of the following properties:
-     *   1. TypeDI's own {@link DISPOSE} constant.
-     *      This acts as an override for the usual {@link Symbol.dispose} logic.
-     *   2. {@link Symbol.dispose}.
-     *   3. {@link Symbol.asyncDispose}.
-     *   4. For backwards compatibility, we maintain support for an ordinary dispose method.
-     *      However, this remnant is not ideal, as it may result in unexpected behaviour.
-     *
-     * For the uninitiated, both {@link Symbol.dispose} and {@link Symbol.asyncDispose}
-     * are parts of the newly-created (as of 2023) Explicit Resource Management proposal:
-     * <https://tc39.es/proposal-explicit-resource-management/>.
-     *
-     * As a result, we ensure that they exist in the environment before checking for
-     * their existence on the target value.  If the checks below did not exist, if
-     * `Symbol.dispose` evaluated to `undefined`, we would be searching for an
-     * `undefined` property on the target value, which is unwanted behaviour.
-     *
-     * One important distinction from the previous behaviour, however, is that this
-     * method no longer swallows promises from calls to a service's disposal method.
-     * (This is, quite frankly, an absolutely terrible idea.)
-     *
-     * This allows the caller of the `reset`/`remove` calls to actually handle errors,
-     * instead of hoping that the service in question's disposal method won't throw
-     * any unexpected errors.
-     *
-     * One aspect of note is that now, a call to `remove` or `reset` will result in a
-     * `Promise`, which may be rejected.  This is a worthy breakage, as the previous
-     * behaviour of returning nothing means we have a safe migration path to the new
-     * behaviour.  Furthermore, it is a required change, as future revisions of Node
-     * will quit the process in the case of an uncaught rejected promise.
-     */
     const disposeMethod = (
       (subject as ObjectWithDISymbolDispose)[DISPOSE] ??
-      (Symbol.dispose && (subject as ObjectWithSymbolDispose)[Symbol.dispose]) ?? 
-      (Symbol.asyncDispose && (subject as ObjectWithSymbolAsyncDispose)[Symbol.asyncDispose]) ?? 
       // eslint-disable-next-line @typescript-eslint/unbound-method
+
+      /**
+       * Keep compatibility with the old .dispose method for now.
+       * It's something we'd hopefully be able to get rid of in future.
+       */
       (subject as ObjectWithDisposeMethod).dispose
     );
 

--- a/src/index.mts
+++ b/src/index.mts
@@ -1,3 +1,5 @@
+export { DISPOSE as OnDispose } from './constants/dispose.const.mjs';
+
 export { JSService } from './decorators/js-service.decorator.mjs';
 export { Service } from './decorators/service.decorator.mjs';
 
@@ -29,6 +31,13 @@ export { ContainerTreeVisitor, VisitRetrievalOptions } from './interfaces/tree-v
 export { Constructable } from './types/constructable.type.mjs';
 export { ContainerIdentifier } from './types/container-identifier.type.mjs';
 export { ContainerScope } from './types/container-scope.type.mjs';
+export {
+  AnyDisposableObject,
+  ObjectWithDISymbolDispose,
+  ObjectWithDisposeMethod,
+  ObjectWithSymbolAsyncDispose,
+  ObjectWithSymbolDispose
+} from './types/disposable-objects.type.mjs';
 export { ExtractToken } from './types/extract-token.type.mjs';
 export { ServiceIdentifierLocation } from './types/service-identifier-location.type.mjs';
 export { ServiceIdentifier } from './types/service-identifier.type.mjs';

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -1,0 +1,16 @@
+import { DISPOSE } from "../constants/dispose.const.mjs";
+import { Disposable } from "./disposable.type";
+
+export interface ObjectWithSymbolDispose {
+    [Symbol.dispose](): void;
+}
+
+export interface ObjectWithSymbolAsyncDispose {
+    [Symbol.asyncDispose](): Promise<void>;
+}
+
+export interface ObjectWithDISymbolDispose {
+    [DISPOSE](): void | Promise<void>;
+}
+
+export type ObjectWithDisposeMethod = Pick<Disposable, 'dispose'>;

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -14,3 +14,9 @@ export interface ObjectWithDISymbolDispose {
 }
 
 export type ObjectWithDisposeMethod = Pick<Disposable, 'dispose'>;
+
+export type AnyDisposableObject =
+    | ObjectWithSymbolDispose
+    | ObjectWithSymbolAsyncDispose
+    | ObjectWithDISymbolDispose
+    | ObjectWithDisposeMethod;

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -1,5 +1,6 @@
 import { DISPOSE } from "../constants/dispose.const.mjs";
-import { Disposable } from "./disposable.type";
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { Disposable } from "./disposable.type.mjs";
 
 /**
  * An object with a {@link Symbol.dispose} member, which is used
@@ -49,10 +50,10 @@ export interface ObjectWithDisposeMethod {
 /**
  * An object implementing any of the 4 disposal methods supported by the container:
  * 
- * @see {@link ObjectWithSymbolDispose}
- * @see {@link ObjectWithSymbolAsyncDispose}
- * @see {@link ObjectWithDISymbolDispose}
- * @see {@link ObjectWithDisposeMethod}
+ * @see {@link ObjectWithSymbolDispose | `Symbol.dispose`}
+ * @see {@link ObjectWithSymbolAsyncDispose | `Symbol.disposeAsync`}
+ * @see {@link ObjectWithDISymbolDispose | `DISPOSE`}
+ * @see {@link ObjectWithDisposeMethod | `"dispose"` (legacy; no longer recommended)}
  */
 export type AnyDisposableObject =
     | ObjectWithSymbolDispose

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -48,7 +48,7 @@ export interface ObjectWithDisposeMethod {
 }
 
 /**
- * An object implementing any of the 4 disposal methods supported by the container:
+ * An object implementing any of the 4 disposal methods supported by the container, in order:
  * 
  * @see {@link ObjectWithSymbolDispose | `Symbol.dispose`}
  * @see {@link ObjectWithSymbolAsyncDispose | `Symbol.disposeAsync`}

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -42,7 +42,9 @@ export interface ObjectWithDISymbolDispose {
  * although the {@link Disposable.disposed | disposed}
  * member is not explicitly required in this rendition.
  */
-export type ObjectWithDisposeMethod = Pick<Disposable, 'dispose'>;
+export interface ObjectWithDisposeMethod {
+    dispose(): Promise<void> | void;
+}
 
 /**
  * An object implementing any of the 4 disposal methods supported by the container:

--- a/src/types/disposable-objects.type.mts
+++ b/src/types/disposable-objects.type.mts
@@ -1,20 +1,57 @@
 import { DISPOSE } from "../constants/dispose.const.mjs";
 import { Disposable } from "./disposable.type";
 
+/**
+ * An object with a {@link Symbol.dispose} member, which is used
+ * by the container to dispose of individual services.
+ */
 export interface ObjectWithSymbolDispose {
     [Symbol.dispose](): void;
 }
 
+/**
+ * An object with a {@link Symbol.asyncDispose} member, which is used
+ * by the container to dispose of individual services in an asynchronous manner.
+ */
 export interface ObjectWithSymbolAsyncDispose {
     [Symbol.asyncDispose](): Promise<void>;
 }
 
+/**
+ * An object with the container-supported {@link DISPOSE} member
+ * set to a function which returns either nothing, or a Promise
+ * containing nothing.
+ * 
+ * @example
+ * Here is an example:
+ * ```ts
+ * @Service([ ])
+ * export class MyService implements ObjectWithDISymbolDispose {
+ *   [OnDispose]() { }
+ * }
+ * ```
+ */
 export interface ObjectWithDISymbolDispose {
     [DISPOSE](): void | Promise<void>;
 }
 
+/**
+ * An object implementing a singular disposal method.
+ * 
+ * This is very similar to {@link Disposable},
+ * although the {@link Disposable.disposed | disposed}
+ * member is not explicitly required in this rendition.
+ */
 export type ObjectWithDisposeMethod = Pick<Disposable, 'dispose'>;
 
+/**
+ * An object implementing any of the 4 disposal methods supported by the container:
+ * 
+ * @see {@link ObjectWithSymbolDispose}
+ * @see {@link ObjectWithSymbolAsyncDispose}
+ * @see {@link ObjectWithDISymbolDispose}
+ * @see {@link ObjectWithDisposeMethod}
+ */
 export type AnyDisposableObject =
     | ObjectWithSymbolDispose
     | ObjectWithSymbolAsyncDispose

--- a/test/features/symbolic-dispose.spec.ts
+++ b/test/features/symbolic-dispose.spec.ts
@@ -1,0 +1,3 @@
+describe('Symbolic Disposal', () => {
+    
+});


### PR DESCRIPTION
This PR introduces the ability for the container to utilise a service's
`Symbol.dispose` method, along with `asyncDispose` to dispose of it.

A new token, aptly named `DISPOSE` is also introduced, which allows
the caller to prevent the calling of the native, Symbol-based methods,
in favour of a method dedicated to disposing the service when the DI
container tells it to.  This allows the service to provide custom handling
for DI-incurred disposals.

Compatibility with the old, string-based `dispose` method API is kept,
to prevent breakages in current applications.  However, migration away
from this is strongly recommended, as it may cause unexpected behaviour.

Fixes https://github.com/freshgum-bubbles/typedi/issues/4.