### PR TITLE
fix(ci): remove esm2015 script invocation

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -100,7 +100,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
       - run: pnpm install
-      - run: pnpm run build:es2015
       - run: pnpm run build:esm5
       - run: pnpm run build:cjs
       - run: pnpm run build:umd


### PR DESCRIPTION
This is primarily for #79, as it removes the script from the package.