### PR TITLE
Experimental support for Identifier Presence Scopes

### DIFF
--- a/.changeset/nine-kings-mix.md
+++ b/.changeset/nine-kings-mix.md
@@ -16,7 +16,7 @@ Container.set({ id: NAME, value: 'Joanna' });
 
 // Ensure we can access the identifier via Container.get(A).
 if (Container.has(NAME, false, IdentifierScope.Singular)) {
-    console.log(Container.get(NAME));
+  console.log(Container.get(NAME));
 }
 
 // This will throw:

--- a/.changeset/nine-kings-mix.md
+++ b/.changeset/nine-kings-mix.md
@@ -1,0 +1,24 @@
+---
+'@freshgum/typedi': minor
+---
+
+The expected scope of an identifier can now be passed to functions such as `Container.has` to ensure that the identifier can be accessed via the expected method.
+
+This fixes use-cases where an identifier may either point at a singular value, or multiple values.
+In those cases, `Container.has(A)` does not provide any guarantees that `Container.get(A)` will not throw.
+
+As an example...
+
+```ts
+const NAME = new Token<string>('Name');
+
+Container.set({ id: NAME, value: 'Joanna' });
+
+// Ensure we can access the identifier via Container.get(A).
+if (Container.has(NAME, false, IdentifierScope.Singular)) {
+    console.log(Container.get(NAME));
+}
+
+// This will throw:
+Container.getMany(NAME);
+```

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1504,7 +1504,11 @@ export class ContainerInstance implements Disposable {
     /** If Self() is used, do not use recursion. */
     const recursive = !isSelf;
 
-    const identifierIsPresent = targetContainer.has(identifier, recursive, isMany ? IdentifierScope.Many : IdentifierScope.Singular);
+    const identifierIsPresent = targetContainer.has(
+      identifier,
+      recursive,
+      isMany ? IdentifierScope.Many : IdentifierScope.Singular
+    );
 
     /**
      * Straight away, check if optional was declared.

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -1504,7 +1504,7 @@ export class ContainerInstance implements Disposable {
     /** If Self() is used, do not use recursion. */
     const recursive = !isSelf;
 
-    const identifierIsPresent = targetContainer.has(identifier, recursive);
+    const identifierIsPresent = targetContainer.has(identifier, recursive, isMany ? IdentifierPresenceScope.Many : IdentifierPresenceScope.Singular);
 
     /**
      * Straight away, check if optional was declared.

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -35,7 +35,7 @@ import { MultiIDLookupResponse } from './types/multi-id-lookup-response.type.mjs
 import { ManyServicesMetadata } from './interfaces/many-services-metadata.interface.mjs';
 import { isArray } from './utils/is-array.util.mjs';
 import { NativeError } from './constants/minification/native-error.const.mjs';
-import { IdentifierPresenceScope } from './types/identifier-presence-scope.type.mjs';
+import { IdentifierScope } from './types/identifier-scope.type.mjs';
 
 /**
  * A list of IDs which, when passed to `.has`, always return true.
@@ -149,7 +149,7 @@ export class ContainerInstance implements Disposable {
    * @throws Error
    * This exception is thrown if the container has been disposed.
    */
-  public has<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true, scope: IdentifierPresenceScope): boolean {
+  public has<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true, scope: IdentifierScope): boolean {
     this.throwIfDisposed();
 
     if (ALWAYS_RESOLVABLE.includes(identifier)) {
@@ -186,18 +186,18 @@ export class ContainerInstance implements Disposable {
   protected getIdentifierLocation<T = unknown>(
     identifier: ServiceIdentifier<T>,
     recursive = true,
-    scope: IdentifierPresenceScope = IdentifierPresenceScope.Any
+    scope: IdentifierScope = IdentifierScope.Any
   ): ServiceIdentifierLocation {
     this.throwIfDisposed();
 
     {
       let isPresentLocally = false;
 
-      if (scope & IdentifierPresenceScope.Many) {
+      if (scope & IdentifierScope.Many) {
         isPresentLocally = this.multiServiceIds.has(identifier);
       }
 
-      if (scope & IdentifierPresenceScope.Singular) {
+      if (scope & IdentifierScope.Singular) {
         isPresentLocally = isPresentLocally || this.metadataMap.has(identifier);
       }
 
@@ -1504,7 +1504,7 @@ export class ContainerInstance implements Disposable {
     /** If Self() is used, do not use recursion. */
     const recursive = !isSelf;
 
-    const identifierIsPresent = targetContainer.has(identifier, recursive, isMany ? IdentifierPresenceScope.Many : IdentifierPresenceScope.Singular);
+    const identifierIsPresent = targetContainer.has(identifier, recursive, isMany ? IdentifierScope.Many : IdentifierScope.Singular);
 
     /**
      * Straight away, check if optional was declared.

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -149,7 +149,7 @@ export class ContainerInstance implements Disposable {
    * @throws Error
    * This exception is thrown if the container has been disposed.
    */
-  public has<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true, scope: IdentifierScope): boolean {
+  public has<T = unknown>(identifier: ServiceIdentifier<T>, recursive = true, scope = IdentifierScope.Any): boolean {
     this.throwIfDisposed();
 
     if (ALWAYS_RESOLVABLE.includes(identifier)) {

--- a/src/index.mts
+++ b/src/index.mts
@@ -30,6 +30,7 @@ export { Constructable } from './types/constructable.type.mjs';
 export { ContainerIdentifier } from './types/container-identifier.type.mjs';
 export { ContainerScope } from './types/container-scope.type.mjs';
 export { ExtractToken } from './types/extract-token.type.mjs';
+export { IdentifierScope } from './types/identifier-scope.type.mjs';
 export { ServiceIdentifierLocation } from './types/service-identifier-location.type.mjs';
 export { ServiceIdentifier } from './types/service-identifier.type.mjs';
 export { ResolutionConstraintFlag, ResolutionConstraintsDescriptor } from './types/resolution-constraint.type.mjs';

--- a/src/types/identifier-presence-scope.type.mts
+++ b/src/types/identifier-presence-scope.type.mts
@@ -1,0 +1,16 @@
+/**
+ * A specification of how an identifier is implemented inside a container.
+ */
+export const enum IdentifierPresenceScope {
+    /** The identifier is implemented as a group of values. */
+    Many = 0b10,
+
+    /** The identifier is implemented as a singular item.  */
+    Singular = 0b01,
+
+    /**
+     * The identifier is either implemented as {@link IdentifierPresenceScope.Many | a group of values},
+     * or {@link IdentifierPresenceScope.Singular | a singular value}.
+     */
+    Any = 0b11
+}

--- a/src/types/identifier-scope.type.mts
+++ b/src/types/identifier-scope.type.mts
@@ -1,7 +1,7 @@
 /**
  * A specification of how an identifier is implemented inside a container.
  */
-export const enum IdentifierPresenceScope {
+export const enum IdentifierScope {
     /** The identifier is implemented as a group of values. */
     Many = 0b10,
 
@@ -9,8 +9,8 @@ export const enum IdentifierPresenceScope {
     Singular = 0b01,
 
     /**
-     * The identifier is either implemented as {@link IdentifierPresenceScope.Many | a group of values},
-     * or {@link IdentifierPresenceScope.Singular | a singular value}.
+     * The identifier is either implemented as {@link IdentifierScope.Many | a group of values},
+     * or {@link IdentifierScope.Singular | a singular value}.
      */
     Any = 0b11
 }

--- a/src/types/identifier-scope.type.mts
+++ b/src/types/identifier-scope.type.mts
@@ -2,15 +2,15 @@
  * A specification of how an identifier is implemented inside a container.
  */
 export const enum IdentifierScope {
-    /** The identifier is implemented as a group of values. */
-    Many = 0b10,
+  /** The identifier is implemented as a group of values. */
+  Many = 0b10,
 
-    /** The identifier is implemented as a singular item.  */
-    Singular = 0b01,
+  /** The identifier is implemented as a singular item.  */
+  Singular = 0b01,
 
-    /**
-     * The identifier is either implemented as {@link IdentifierScope.Many | a group of values},
-     * or {@link IdentifierScope.Singular | a singular value}.
-     */
-    Any = 0b11
+  /**
+   * The identifier is either implemented as {@link IdentifierScope.Many | a group of values},
+   * or {@link IdentifierScope.Singular | a singular value}.
+   */
+  Any = 0b11,
 }


### PR DESCRIPTION
Currently, `Container.has(A)` provides no guarantees that `Container.get(A)`
will not throw.  There is no way to check this, aside from checking internal maps
such as `metadataMap` and `multiServiceIds`.

This presents an interesting problem: as `Container.get(A)` may throw, even if
you've checked for its presence, what do you do?

1. You could wrap each `Container.get(A)` call in a `try { } catch { }`... no.
2. You could hook into container internals, as described above.
3. Nag the maintainer to implement something sane like this.

Number 3 is what we're going for.

## Related Changes

### `@Service()` error message patch

XXX