### PR TITLE
Fix acceptTreeVisitor: remove visitors which throw in visitContainer

### DIFF
--- a/.changeset/mean-beans-begin.md
+++ b/.changeset/mean-beans-begin.md
@@ -1,0 +1,5 @@
+---
+'@freshgum/typedi': patch
+---
+
+The internal visitor collection now removes visitors which throw an error in their visitContainer method.

--- a/src/visitor-collection.class.mts
+++ b/src/visitor-collection.class.mts
@@ -125,28 +125,31 @@ export class VisitorCollection implements Disposable {
       this.anyVisitorsPresent = true;
     }
 
-    /**
-     * Directly call the visitor's "visitContainer" method
-     * to initialise it upon the given container.
-     *
-     * Implementation detail: We don't provide any sort of protection against
-     * this being called again on a different container.
-     * The visitor would be able to handle that themselves, as the API states
-     * that any call to `visitContainer` means that the visitor was added
-     * to a container.
-     */
-    const isAllowedToAttachVisitor = visitor.visitContainer?.(container);
+    let isAllowedToAttachVisitor: boolean | undefined;
 
-    /**
-     * If a false-y return value was returned to signal that the visitor
-     * should not be attached to the given container, immediately remove it.
-     */
-    if (!isAllowedToAttachVisitor) {
-      this.removeVisitorFromCollection(visitor);
-      return false;
+    try {
+      /**
+       * Directly call the visitor's "visitContainer" method
+       * to initialise it upon the given container.
+       *
+       * Implementation detail: We don't provide any sort of protection against
+       * this being called again on a different container.
+       * The visitor would be able to handle that themselves, as the API states
+       * that any call to `visitContainer` means that the visitor was added
+       * to a container.
+       */
+      isAllowedToAttachVisitor = visitor.visitContainer?.(container);
+    } finally {
+      /**
+       * If a false-y return value was returned to signal that the visitor
+       * should not be attached to the given container, immediately remove it.
+       */
+      if (!isAllowedToAttachVisitor) {
+        this.removeVisitorFromCollection(visitor);
+      }
     }
 
-    return true;
+    return isAllowedToAttachVisitor;
   }
 
   /**

--- a/test/features/tree-visitor.spec.ts
+++ b/test/features/tree-visitor.spec.ts
@@ -218,6 +218,20 @@ describe('Tree Visitors', () => {
         expect(visitor.visitOrphanedContainer).toHaveBeenCalledTimes(0);
       });
 
+      it('should remove visitors which throw in visitContainer', () => {
+        const visitor = createVisitorMock();
+        visitor.visitContainer.mockImplementation(() => { throw new Error(); });
+
+        /** Attach the visitor to a container. */
+        expect(() => Container.acceptTreeVisitor(visitor)).toThrow(Error);
+        
+        const testKey = new Token<string>();
+        Container.setValue(testKey, 'my value');
+
+        expect(visitor.visitNewService).toHaveBeenCalledTimes(0);
+        expect(Container.detachTreeVisitor(visitor)).toBe(false);
+      });
+
       /**
        * We skip the inverse case: visitors that return true are given events.
        * This is because we already implicitly test this (numerous times) above.

--- a/test/features/tree-visitor.spec.ts
+++ b/test/features/tree-visitor.spec.ts
@@ -220,11 +220,13 @@ describe('Tree Visitors', () => {
 
       it('should remove visitors which throw in visitContainer', () => {
         const visitor = createVisitorMock();
-        visitor.visitContainer.mockImplementation(() => { throw new Error(); });
+        visitor.visitContainer.mockImplementation(() => {
+          throw new Error();
+        });
 
         /** Attach the visitor to a container. */
         expect(() => Container.acceptTreeVisitor(visitor)).toThrow(Error);
-        
+
         const testKey = new Token<string>();
         Container.setValue(testKey, 'my value');
 


### PR DESCRIPTION
Fix a leak in `VisitorCollection`, where a visitor with a `visitContainer` method 
(which throws an error) is not removed from the container.