### PR TITLE
SynchronousDisposable

### DIFF
--- a/.changeset/khaki-steaks-jog.md
+++ b/.changeset/khaki-steaks-jog.md
@@ -5,32 +5,34 @@
 A new `SynchronousDisposable` class has been added to `contrib/util`. This class manages the small amount of boilerplate involved in setting up and managing a container-compliant disposable object (implementing `Disposable`).
 
 As an example...
+
 ```ts
 import { Disposable } from '@freshgum/typedi';
 import { SynchronousDisposable } from '@freshgum/typedi/contrib/util/synchronous-disposable';
 
 export class MyClass extends SynchronousDisposable implements Disposable {
-    public override dispose () {
-        super.dispose();
-        // Run custom disposal logic here...
+  public override dispose() {
+    super.dispose();
+    // Run custom disposal logic here...
+  }
+
+  public myMethod() {
+    if (this.disposed) {
+      throw new Error('The MyClass instance has already been disposed.');
     }
 
-    public myMethod () {
-        if (this.disposed) {
-            throw new Error('The MyClass instance has already been disposed.');
-        }
-
-        // ...
-    }
+    // ...
+  }
 }
 ```
 
 It has three responsibilities:
-  1. Throwing if `dispose` has been called more than once.
-  2. Setting the `disposed` property.
-  3. Being compliant with the container.
+
+1. Throwing if `dispose` has been called more than once.
+2. Setting the `disposed` property.
+3. Being compliant with the container.
 
 To keep the API surface minimal, no other functionality has or will be implemented via this class.
 
-The use-case of *writing methods without worrying about whether the object has been disposed* is being investigated,
+The use-case of _writing methods without worrying about whether the object has been disposed_ is being investigated,
 as the container makes extensive use of disposal itself.

--- a/.changeset/khaki-steaks-jog.md
+++ b/.changeset/khaki-steaks-jog.md
@@ -1,0 +1,36 @@
+---
+'@freshgum/typedi': minor
+---
+
+A new `SynchronousDisposable` class has been added to `contrib/util`. This class manages the small amount of boilerplate involved in setting up and managing a container-compliant disposable object (implementing `Disposable`).
+
+As an example...
+```ts
+import { Disposable } from '@freshgum/typedi';
+import { SynchronousDisposable } from '@freshgum/typedi/contrib/util/synchronous-disposable';
+
+export class MyClass extends SynchronousDisposable implements Disposable {
+    public override dispose () {
+        super.dispose();
+        // Run custom disposal logic here...
+    }
+
+    public myMethod () {
+        if (this.disposed) {
+            throw new Error('The MyClass instance has already been disposed.');
+        }
+
+        // ...
+    }
+}
+```
+
+It has three responsibilities:
+  1. Throwing if `dispose` has been called more than once.
+  2. Setting the `disposed` property.
+  3. Being compliant with the container.
+
+To keep the API surface minimal, no other functionality has or will be implemented via this class.
+
+The use-case of *writing methods without worrying about whether the object has been disposed* is being investigated,
+as the container makes extensive use of disposal itself.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,12 @@
       "import": "./build/esm5/contrib/transient-ref/index.mjs",
       "node": "./build/esm5/contrib/transient-ref/index.mjs",
       "bun": "./src/contrib/transient-ref/index.mts"
+    },
+    "./contrib/util/synchronous-disposable": {
+      "types": "./build/esm5/contrib/util/synchronous-disposable.d.mts",
+      "import": "./build/esm5/contrib/util/synchronous-disposable.mjs",
+      "node": "./build/esm5/contrib/util/synchronous-disposable.mjs",
+      "bun": "./src/contrib/util/synchronous-disposable.class.mts"
     }
   },
   "engines": {

--- a/src/contrib/util/synchronous-disposable.class.mts
+++ b/src/contrib/util/synchronous-disposable.class.mts
@@ -1,0 +1,13 @@
+import { Disposable } from "../../types/disposable.type.mjs";
+
+export class SynchronousDisposable implements Disposable {
+    public disposed = false;
+
+    dispose() {
+        if (this.disposed) {
+            throw new Error('The object has already been disposed.');
+        }
+
+        this.disposed = true;
+    }
+}

--- a/src/contrib/util/synchronous-disposable.class.mts
+++ b/src/contrib/util/synchronous-disposable.class.mts
@@ -1,13 +1,13 @@
-import { Disposable } from "../../types/disposable.type.mjs";
+import { Disposable } from '../../types/disposable.type.mjs';
 
 export class SynchronousDisposable implements Disposable {
-    public disposed = false;
+  public disposed = false;
 
-    dispose() {
-        if (this.disposed) {
-            throw new Error('The object has already been disposed.');
-        }
-
-        this.disposed = true;
+  dispose() {
+    if (this.disposed) {
+      throw new Error('The object has already been disposed.');
     }
+
+    this.disposed = true;
+  }
 }

--- a/test/contrib/util/synchronous-disposable.spec.ts
+++ b/test/contrib/util/synchronous-disposable.spec.ts
@@ -1,0 +1,33 @@
+import { Disposable } from 'internal:typedi/types/disposable.type.mjs';
+import { SynchronousDisposable } from '../../../src/contrib/util/synchronous-disposable.class.mjs';
+
+describe('SynchronousDisposable', () => {
+    it('should be a function', () => {
+        expect(typeof SynchronousDisposable).toStrictEqual('function');
+    });
+    
+    it('should implement the container-provided\'s Disposable type', () => {
+        const temp: Disposable = new SynchronousDisposable();
+        // TODO: set up proper jest-tsc testing
+        expect(typeof temp).toBe('object');
+    });
+
+    it('should have a "disposed" property initially set to false', () => {
+        const disposable = new SynchronousDisposable();
+        expect(disposable.disposed).toStrictEqual(false);
+    });
+    
+    describe('.dispose()', () => {
+        it('should set "disposed" to true', () => {
+            const disposable = new SynchronousDisposable();
+            expect(() => disposable.dispose()).not.toThrow();
+            expect(disposable.disposed).toStrictEqual(true);
+        });
+
+        it('should throw if it has already been called', () => {
+            const disposable = new SynchronousDisposable();
+            expect(() => disposable.dispose()).not.toThrow();
+            expect(() => disposable.dispose()).toThrow();
+        });
+    });
+});

--- a/test/contrib/util/synchronous-disposable.spec.ts
+++ b/test/contrib/util/synchronous-disposable.spec.ts
@@ -2,32 +2,32 @@ import { Disposable } from 'internal:typedi/types/disposable.type.mjs';
 import { SynchronousDisposable } from '../../../src/contrib/util/synchronous-disposable.class.mjs';
 
 describe('SynchronousDisposable', () => {
-    it('should be a function', () => {
-        expect(typeof SynchronousDisposable).toStrictEqual('function');
-    });
-    
-    it('should implement the container-provided\'s Disposable type', () => {
-        const temp: Disposable = new SynchronousDisposable();
-        // TODO: set up proper jest-tsc testing
-        expect(typeof temp).toBe('object');
+  it('should be a function', () => {
+    expect(typeof SynchronousDisposable).toStrictEqual('function');
+  });
+
+  it("should implement the container-provided's Disposable type", () => {
+    const temp: Disposable = new SynchronousDisposable();
+    // TODO: set up proper jest-tsc testing
+    expect(typeof temp).toBe('object');
+  });
+
+  it('should have a "disposed" property initially set to false', () => {
+    const disposable = new SynchronousDisposable();
+    expect(disposable.disposed).toStrictEqual(false);
+  });
+
+  describe('.dispose()', () => {
+    it('should set "disposed" to true', () => {
+      const disposable = new SynchronousDisposable();
+      expect(() => disposable.dispose()).not.toThrow();
+      expect(disposable.disposed).toStrictEqual(true);
     });
 
-    it('should have a "disposed" property initially set to false', () => {
-        const disposable = new SynchronousDisposable();
-        expect(disposable.disposed).toStrictEqual(false);
+    it('should throw if it has already been called', () => {
+      const disposable = new SynchronousDisposable();
+      expect(() => disposable.dispose()).not.toThrow();
+      expect(() => disposable.dispose()).toThrow();
     });
-    
-    describe('.dispose()', () => {
-        it('should set "disposed" to true', () => {
-            const disposable = new SynchronousDisposable();
-            expect(() => disposable.dispose()).not.toThrow();
-            expect(disposable.disposed).toStrictEqual(true);
-        });
-
-        it('should throw if it has already been called', () => {
-            const disposable = new SynchronousDisposable();
-            expect(() => disposable.dispose()).not.toThrow();
-            expect(() => disposable.dispose()).toThrow();
-        });
-    });
+  });
 });


### PR DESCRIPTION
The changeset...

A new `SynchronousDisposable` class has been added to `contrib/util`. This class manages the small amount of boilerplate involved in setting up and managing a container-compliant disposable object (implementing `Disposable`).

As an example...
```ts
import { Disposable } from '@freshgum/typedi';
import { SynchronousDisposable } from '@freshgum/typedi/contrib/util/synchronous-disposable';

export class MyClass extends SynchronousDisposable implements Disposable {
    public override dispose () {
        super.dispose();
        // Run custom disposal logic here...
    }

    public myMethod () {
        if (this.disposed) {
            throw new Error('The MyClass instance has already been disposed.');
        }

        // ...
    }
}
```

It has three responsibilities:
  1. Throwing if `dispose` has been called more than once.
  2. Setting the `disposed` property.
  3. Being compliant with the container.

To keep the API surface minimal, no other functionality has or will be implemented via this class.

The use-case of *writing methods without worrying about whether the object has been disposed* is being investigated,
as the container makes extensive use of disposal itself.
