### PR TITLE
Fix "ContainerRegistry.removeContainer"

### DIFF
--- a/.changeset/dry-dolls-occur.md
+++ b/.changeset/dry-dolls-occur.md
@@ -1,0 +1,5 @@
+---
+'@freshgum/typedi': patch
+---
+
+The `ContainerRegistry.removeContainer` method no longer disposes already-disposed containers. This may have been an issue if a container was disposed, and then `removeContainer` was called; the call would always fail, as the registry attempted a disposal upon the container when doing so was invalid.

--- a/src/container-registry.class.mts
+++ b/src/container-registry.class.mts
@@ -106,7 +106,7 @@ export class ContainerRegistry {
 
     /** We dispose all registered classes in the container. */
     if (!registeredContainer.disposed) {
-      registeredContainer.dispose();
+      await registeredContainer.dispose();
     }
   }
 }

--- a/src/container-registry.class.mts
+++ b/src/container-registry.class.mts
@@ -105,6 +105,8 @@ export class ContainerRegistry {
     ContainerRegistry.containerMap.delete(container.id);
 
     /** We dispose all registered classes in the container. */
-    await registeredContainer.dispose();
+    if (!registeredContainer.disposed) {
+      registeredContainer.dispose();
+    }
   }
 }


### PR DESCRIPTION
The `ContainerRegistry.removeContainer` method no longer disposes already-disposed containers. This may have been an issue if a container was disposed, and then `removeContainer` was called; the call would always fail, as the registry attempted a disposal upon the container when doing so was invalid.