### PR TITLE
Export ContainerRegistryError from package index

### DIFF
--- a/.changeset/mean-roses-yawn.md
+++ b/.changeset/mean-roses-yawn.md
@@ -1,0 +1,5 @@
+---
+'@freshgum/typedi': patch
+---
+
+The `ContainerRegistryError` constructor is now exported from the package index. This allows for greater pattern-matching of errors which occur as a result of invalid registry operations.

--- a/src/index.mts
+++ b/src/index.mts
@@ -3,6 +3,7 @@ export { Service } from './decorators/service.decorator.mjs';
 
 export * from './error/cannot-instantiate-builtin-error.mjs';
 export * from './error/cannot-instantiate-value.error.mjs';
+export * from './error/container-registry-error.error.mjs';
 export * from './error/service-not-found.error.mjs';
 
 export { HostContainer } from './functions/host-container.function.mjs';


### PR DESCRIPTION
This change exports the `ContainerRegistryError` constructor from the package index.

As the constructor is now considered stable, it is safe to be publicly exposed.