### PR TITLE
ESService Decorator

### DIFF
--- a/.changeset/forty-experts-retire.md
+++ b/.changeset/forty-experts-retire.md
@@ -1,0 +1,24 @@
+---
+'@freshgum/typedi': minor
+---
+
+**We now support ES decorators**! Grab the new ESService decorator from contrib/es!
+
+To use this, you'll need to disable `experimentalDecorators` in your TypeScript
+configuration file.  Note that, by doing this, you won't be able to utilise the
+legacy decorators included in the package (`Service`).
+
+Here's an example:
+
+```ts
+import { ESService } from '@freshgum/typedi/contrib/es';
+
+@ESService([ ])
+export class MyService { }
+```
+
+Note that the **legacy decorators have not been removed** for backwards-compatibility
+reasons: you're still able to use them just as before.
+
+Many thanks to Axel Rauschmayer for providing
+[a very detailed guide re: ES decorators](https://2ality.com/2022/10/javascript-decorators.html).

--- a/.changeset/forty-experts-retire.md
+++ b/.changeset/forty-experts-retire.md
@@ -5,7 +5,7 @@
 **We now support ES decorators**! Grab the new ESService decorator from contrib/es!
 
 To use this, you'll need to disable `experimentalDecorators` in your TypeScript
-configuration file.  Note that, by doing this, you won't be able to utilise the
+configuration file. Note that, by doing this, you won't be able to utilise the
 legacy decorators included in the package (`Service`).
 
 Here's an example:
@@ -13,8 +13,8 @@ Here's an example:
 ```ts
 import { ESService } from '@freshgum/typedi/contrib/es';
 
-@ESService([ ])
-export class MyService { }
+@ESService([])
+export class MyService {}
 ```
 
 Note that the **legacy decorators have not been removed** for backwards-compatibility

--- a/docs/docs/guide/es-decorators.md
+++ b/docs/docs/guide/es-decorators.md
@@ -7,8 +7,8 @@ sidebar_position: 3
 TypeScript users have long been accustomed to the `experimentalDecorators` option, which
 has allowed for the use of a TypeScript-specific decorator API.  However, **this is changing**.
 
-Without delving into an extreme amount of detail [(Axel R.'s blog does that quite well)][axel-r-decorators],
-(as of 10/18/2023) decorators have now been standarized as part of the TC39 process.
+Without delving into an extreme amount of detail [(Axel R.'s blog does that very well)][axel-r-decorators],
+as of 10/18/2023, decorators have now been standarized as part of the TC39 process.
 
 TypeScript 5.0 [introduced support for this new decorator API][ts-blog-5.0-release-decorators],
 and packages have slowly begun transitioning to it.  It's now considered stable, so support

--- a/docs/docs/guide/es-decorators.md
+++ b/docs/docs/guide/es-decorators.md
@@ -1,0 +1,41 @@
+---
+sidebar_position: 3
+---
+
+# ES Decorators
+
+TypeScript users have long been accustomed to the `experimentalDecorators` option, which
+has allowed for the use of a TypeScript-specific decorator API.  However, **this is changing**.
+
+Without delving into an extreme amount of detail [(Axel R.'s blog does that quite well)][axel-r-decorators],
+(as of 10/18/2023) decorators have now been standarized as part of the TC39 process.
+
+TypeScript 5.0 [introduced support for this new decorator API][ts-blog-5.0-release-decorators],
+and packages have slowly begun transitioning to it.  It's now considered stable, so support
+for it has been added to the TypeDI++ project as part of a contributory package.
+
+## Example
+
+:::note
+
+To use these decorators, you'll need to **disable the `experimentalDecorators` option in your `tsconfig.json`**,
+and migrate your usage of the `Service` decorator to the `ESService` decorator provided in `@freshgum/typedi/contrib/es`.
+
+:::
+
+As a quick example of the above:
+
+```ts
+import { ESService } from '@freshgum/typedi/contrib/es';
+
+@ESService([ ])
+export class MyService { }
+```
+
+## Legacy Decorators
+
+For backwards compatibility, the usage of legacy decorators is still supported.
+Due to their prevalence, they are not deprecated.
+
+[ts-blog-5.0-release-decorators]: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators
+[axel-r-decorators]: https://2ality.com/2022/10/javascript-decorators.html

--- a/docs/docs/guide/es-decorators.md
+++ b/docs/docs/guide/es-decorators.md
@@ -12,7 +12,7 @@ as of 10/18/2023, decorators have now been standarized as part of the TC39 proce
 
 TypeScript 5.0 [introduced support for this new decorator API][ts-blog-5.0-release-decorators],
 and packages have slowly begun transitioning to it.  It's now considered stable, so support
-for it has been added to the TypeDI++ project as part of a contributory package.
+for it has been added to the TypeDI++ project ([as of v0.7.0][gh-project-changelog]) as part of a contributory package.
 
 ## Example
 

--- a/docs/docs/guide/es-decorators.md
+++ b/docs/docs/guide/es-decorators.md
@@ -35,7 +35,11 @@ export class MyService { }
 ## Legacy Decorators
 
 For backwards compatibility, the usage of legacy decorators is still supported.
-Due to their prevalence, they are not deprecated.
+There's no immediate need to migrate to the new API.
+
+However, documentation will be updated to encourage usage of ES Decorators,
+as the TypeScript team will (most likely) eventually remove support for these decorators.
 
 [ts-blog-5.0-release-decorators]: https://devblogs.microsoft.com/typescript/announcing-typescript-5-0/#decorators
 [axel-r-decorators]: https://2ality.com/2022/10/javascript-decorators.html
+[gh-project-changelog]: https://github.com/freshgum-bubbles/typedi/blob/develop/CHANGELOG.md

--- a/docs/docs/guide/es-decorators.md
+++ b/docs/docs/guide/es-decorators.md
@@ -5,13 +5,13 @@ sidebar_position: 3
 # ES Decorators
 
 TypeScript users have long been accustomed to the `experimentalDecorators` option, which
-has allowed for the use of a TypeScript-specific decorator API.  However, **this is changing**.
+has allowed for the use of a TypeScript-specific decorator API. However, **this is changing**.
 
 Without delving into an extreme amount of detail [(Axel R.'s blog does that very well)][axel-r-decorators],
 as of 10/18/2023, decorators have now been standarized as part of the TC39 process.
 
 TypeScript 5.0 [introduced support for this new decorator API][ts-blog-5.0-release-decorators],
-and packages have slowly begun transitioning to it.  It's now considered stable, so support
+and packages have slowly begun transitioning to it. It's now considered stable, so support
 for it has been added to the TypeDI++ project ([as of v0.7.0][gh-project-changelog]) as part of a contributory package.
 
 ## Example
@@ -28,8 +28,8 @@ As a quick example of the above:
 ```ts
 import { ESService } from '@freshgum/typedi/contrib/es';
 
-@ESService([ ])
-export class MyService { }
+@ESService([])
+export class MyService {}
 ```
 
 ## Legacy Decorators

--- a/package.json
+++ b/package.json
@@ -25,6 +25,13 @@
       "node": "./build/esm5/entry/index.mjs",
       "bun": "./src/index.mts"
     },
+    "./contrib/es": {
+      "types": "./build/esm5/contrib/es/index.d.mts",
+      "import": "./build/esm5/contrib/es/index.mjs",
+      "default": "./build/esm5/contrib/es/index.mjs",
+      "node": "./build/esm5/contrib/es/index.mjs",
+      "bun": "./src/contrib/es/index.mts"
+    },
     "./contrib/transient-ref": {
       "types": "./build/esm5/contrib/transient-ref/index.d.mts",
       "import": "./build/esm5/contrib/transient-ref/index.mjs",

--- a/src/contrib/es/es-service.decorator.mts
+++ b/src/contrib/es/es-service.decorator.mts
@@ -1,6 +1,9 @@
-import { AnyServiceDependency, ServiceOptions, Constructable, Service } from "../../index.mjs";
-import { ServiceOptionsWithDependencies, ServiceOptionsWithoutDependencies } from "../../interfaces/service-options.interface.mjs";
-import { ESClassDecorator } from "../util/es-class-decorator.type.mjs";
+import { AnyServiceDependency, ServiceOptions, Constructable, Service } from '../../index.mjs';
+import {
+  ServiceOptionsWithDependencies,
+  ServiceOptionsWithoutDependencies,
+} from '../../interfaces/service-options.interface.mjs';
+import { ESClassDecorator } from '../util/es-class-decorator.type.mjs';
 
 /**
  * Marks class as a service that can be injected using Container.
@@ -106,7 +109,9 @@ export function ESService<T = unknown>(
  *
  * @returns A decorator which is then used upon a class.
  */
-export function ESService<T = unknown>(options: ServiceOptionsWithDependencies<Constructable<unknown>>): ESClassDecorator<Constructable<T>>;
+export function ESService<T = unknown>(
+  options: ServiceOptionsWithDependencies<Constructable<unknown>>
+): ESClassDecorator<Constructable<T>>;
 export function ESService<T = unknown>(
   optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
   maybeDependencies?: AnyServiceDependency[]
@@ -116,6 +121,9 @@ export function ESService<T = unknown>(
       throw new Error('@ESService() must only be used to decorate classes.');
     }
 
-    Service(optionsOrDependencies as ServiceOptionsWithoutDependencies<T>, maybeDependencies as AnyServiceDependency[])(target);
+    Service(
+      optionsOrDependencies as ServiceOptionsWithoutDependencies<T>,
+      maybeDependencies as AnyServiceDependency[]
+    )(target);
   };
 }

--- a/src/contrib/es/es-service.decorator.mts
+++ b/src/contrib/es/es-service.decorator.mts
@@ -11,7 +11,9 @@ import { ESClassDecorator } from '../util/es-class-decorator.type.mjs';
  * By default, the service shall be registered upon the `defaultContainer` container.
  *
  * @remarks
- * **This is a TypeScript decorator.**
+ * **This is an ES decorator.**
+ * It performs the same as {@link Service}, though it works under
+ * TypeScript 5.0+ when the `experimentalDecorators` option is disabled.
  *
  * @example
  * Here is an example:
@@ -41,7 +43,9 @@ export function ESService<T = unknown>(dependencies: AnyServiceDependency[]): ES
  * By default, the service shall be registered upon the `defaultContainer` container.
  *
  * @remarks
- * **This is a TypeScript decorator.**
+ * **This is an ES decorator.**
+ * It performs the same as {@link Service}, though it works under
+ * TypeScript 5.0+ when the `experimentalDecorators` option is disabled.
  *
  * @example
  * Here is an example:
@@ -81,7 +85,9 @@ export function ESService<T = unknown>(
  * By default, the service shall be registered upon the `defaultContainer` container.
  *
  * @remarks
- * **This is a TypeScript decorator.**
+ * **This is an ES decorator.**
+ * It performs the same as {@link Service}, though it works under
+ * TypeScript 5.0+ when the `experimentalDecorators` option is disabled.
  *
  * @example
  * Here is an example:
@@ -112,11 +118,13 @@ export function ESService<T = unknown>(
 export function ESService<T = unknown>(
   options: ServiceOptionsWithDependencies<Constructable<unknown>>
 ): ESClassDecorator<Constructable<T>>;
+
 export function ESService<T = unknown>(
   optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
   maybeDependencies?: AnyServiceDependency[]
 ): ESClassDecorator<Constructable<T>> {
   return (target: Constructable<T>, context: ClassDecoratorContext) => {
+    // This is probably overcautious.
     if (context.kind !== 'class') {
       throw new Error('@ESService() must only be used to decorate classes.');
     }

--- a/src/contrib/es/es-service.decorator.mts
+++ b/src/contrib/es/es-service.decorator.mts
@@ -1,0 +1,121 @@
+import { AnyServiceDependency, ServiceOptions, Constructable, Service } from "../../index.mjs";
+import { ServiceOptionsWithDependencies, ServiceOptionsWithoutDependencies } from "../../interfaces/service-options.interface.mjs";
+import { ESClassDecorator } from "../util/es-class-decorator.type.mjs";
+
+/**
+ * Marks class as a service that can be injected using Container.
+ * Uses the default options, wherein the class can be passed to `.get` and an instance of it will be returned.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ *
+ * @remarks
+ * **This is a TypeScript decorator.**
+ *
+ * @example
+ * Here is an example:
+ * ```ts
+ * @Service([ ])
+ * class OtherService { }
+ *
+ * @Service([OtherService])
+ * class MyService {
+ *   constructor (private otherService: OtherService) { }
+ * }
+ * ```
+ *
+ * @param dependencies The dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ *
+ * @group Decorators
+ *
+ * @returns A decorator which is then used upon a class.
+ */
+export function ESService<T = unknown>(dependencies: AnyServiceDependency[]): ESClassDecorator<Constructable<T>>;
+
+/**
+ * Marks class as a service that can be injected using Container.
+ * The options allow customization of how the service is injected.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ *
+ * @remarks
+ * **This is a TypeScript decorator.**
+ *
+ * @example
+ * Here is an example:
+ * ```ts
+ * const OTHER_SERVICE = new Token<OtherService>();
+ *
+ * @Service({ id: OTHER_SERVICE }, [ ])
+ * class OtherService { }
+ *
+ * @Service([OTHER_SERVICE])
+ * class MyService {
+ *   constructor (private otherService: OtherService) { }
+ * }
+ * ```
+ *
+ * @param options The options to use for initialisation of the service.
+ * Documentation for the options can be found in ServiceOptions.
+ *
+ * @param dependencies The dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ *
+ * @see {@link ServiceOptions}
+ *
+ * @group Decorators
+ *
+ * @returns A decorator which is then used upon a class.
+ */
+export function ESService<T = unknown>(
+  options: Omit<ServiceOptions<T>, 'dependencies'>,
+  dependencies: AnyServiceDependency[]
+): ESClassDecorator<Constructable<T>>;
+
+/**
+ * Marks class as a service that can be injected using Container.
+ * The options allow customization of how the service is injected.
+ * By default, the service shall be registered upon the `defaultContainer` container.
+ *
+ * @remarks
+ * **This is a TypeScript decorator.**
+ *
+ * @example
+ * Here is an example:
+ * ```ts
+ * const OTHER_SERVICE = new Token<OtherService>();
+ *
+ * @Service({ id: OTHER_SERVICE, dependencies: [ ] })
+ * class OtherService { }
+ *
+ * @Service({ dependencies: [OtherService] })
+ * class MyService {
+ *   constructor (private otherService: OtherService) { }
+ * }
+ * ```
+ *
+ * @param options The options to use for initialisation of the service.
+ * Documentation for the options can be found in ServiceOptions.
+ * The options must also contain the dependencies that the service requires.
+ *
+ * If found, the specified dependencies to provide upon initialisation of this service.
+ * These will be provided to the service as arguments to its constructor.
+ * They must be valid identifiers in the container the service shall be executed under.
+ *
+ * @group Decorators
+ *
+ * @returns A decorator which is then used upon a class.
+ */
+export function ESService<T = unknown>(options: ServiceOptionsWithDependencies<Constructable<unknown>>): ESClassDecorator<Constructable<T>>;
+export function ESService<T = unknown>(
+  optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
+  maybeDependencies?: AnyServiceDependency[]
+): ESClassDecorator<Constructable<T>> {
+  return (target: Constructable<T>, context: ClassDecoratorContext) => {
+    if (context.kind !== 'class') {
+      throw new Error('@ESService() must only be used to decorate classes.');
+    }
+
+    Service(optionsOrDependencies as ServiceOptionsWithoutDependencies<T>, maybeDependencies as AnyServiceDependency[])(target);
+  };
+}

--- a/src/contrib/es/index.mts
+++ b/src/contrib/es/index.mts
@@ -1,0 +1,1 @@
+export { ESService } from './es-service.decorator.mjs';

--- a/src/contrib/util/es-class-decorator.type.mts
+++ b/src/contrib/util/es-class-decorator.type.mts
@@ -1,0 +1,7 @@
+/**
+ * A description of an ES class decorator (as of TypeScript 5.0).
+ *
+ * @typeParam TSubject - The type of function being decorated.
+ * @typeParam TReturn - The return value of the decorator. Defaults to `TSubject | void`.
+ */
+export type ESClassDecorator<TSubject extends Function, TReturn = TSubject | void> = (value: TSubject, context: ClassDecoratorContext) => TReturn;

--- a/src/contrib/util/es-class-decorator.type.mts
+++ b/src/contrib/util/es-class-decorator.type.mts
@@ -4,4 +4,7 @@
  * @typeParam TSubject - The type of function being decorated.
  * @typeParam TReturn - The return value of the decorator. Defaults to `TSubject | void`.
  */
-export type ESClassDecorator<TSubject extends Function, TReturn = TSubject | void> = (value: TSubject, context: ClassDecoratorContext) => TReturn;
+export type ESClassDecorator<TSubject extends Function, TReturn = TSubject | void> = (
+  value: TSubject,
+  context: ClassDecoratorContext
+) => TReturn;

--- a/test/contrib/es/es-service.spec.ts
+++ b/test/contrib/es/es-service.spec.ts
@@ -1,3 +1,21 @@
-describe.skip('ESService', () => {
+import { Container } from "internal:typedi";
+import { createFakeClassDecoratorContext } from "./utils/fake-context.util";
+import { ESService } from "internal:typedi/contrib/es/es-service.decorator.mjs";
 
+// Due to the testing structure, we can't actually use ES Decorators
+// here.  Instead, we have to pretend we're using them, by manually
+// passing descriptors and functions to them.
+// P.S. The actual conformance testing goes on in <test/decorators/Service.spec.ts>
+// This suite just tests parts of required ESService-specific testing.
+describe('ESService', () => {
+    beforeEach(() => Container.reset({ strategy: 'resetValue' }));
+
+    // Note: in <test/contrib/es/utils/es-service-decorator-wrapper.util.ts>, we already test
+    // if the implementation accepts valid invocations with valid ClassDecoratorContext objects.
+    it('should fail if not passed a ClassDecoratorContext', () => {
+        class MyService { }
+
+        const context = createFakeClassDecoratorContext(MyService);
+        expect(() => ESService([ ])(class { }, context)).not.toThrow();
+    });
 });

--- a/test/contrib/es/es-service.spec.ts
+++ b/test/contrib/es/es-service.spec.ts
@@ -1,6 +1,6 @@
-import { Container } from "internal:typedi";
-import { createFakeClassDecoratorContext } from "./utils/fake-context.util";
-import { ESService } from "internal:typedi/contrib/es/es-service.decorator.mjs";
+import { Container } from 'internal:typedi';
+import { createFakeClassDecoratorContext } from './utils/fake-context.util';
+import { ESService } from 'internal:typedi/contrib/es/es-service.decorator.mjs';
 
 // Due to the testing structure, we can't actually use ES Decorators
 // here.  Instead, we have to pretend we're using them, by manually
@@ -8,14 +8,14 @@ import { ESService } from "internal:typedi/contrib/es/es-service.decorator.mjs";
 // P.S. The actual conformance testing goes on in <test/decorators/Service.spec.ts>
 // This suite just tests parts of required ESService-specific testing.
 describe('ESService', () => {
-    beforeEach(() => Container.reset({ strategy: 'resetValue' }));
+  beforeEach(() => Container.reset({ strategy: 'resetValue' }));
 
-    // Note: in <test/contrib/es/utils/es-service-decorator-wrapper.util.ts>, we already test
-    // if the implementation accepts valid invocations with valid ClassDecoratorContext objects.
-    it('should fail if not passed a ClassDecoratorContext', () => {
-        class MyService { }
+  // Note: in <test/contrib/es/utils/es-service-decorator-wrapper.util.ts>, we already test
+  // if the implementation accepts valid invocations with valid ClassDecoratorContext objects.
+  it('should fail if not passed a ClassDecoratorContext', () => {
+    class MyService {}
 
-        const context = createFakeClassDecoratorContext(MyService);
-        expect(() => ESService([ ])(class { }, context)).not.toThrow();
-    });
+    const context = createFakeClassDecoratorContext(MyService);
+    expect(() => ESService([])(class {}, context)).not.toThrow();
+  });
 });

--- a/test/contrib/es/es-service.spec.ts
+++ b/test/contrib/es/es-service.spec.ts
@@ -1,0 +1,3 @@
+describe.skip('ESService', () => {
+
+});

--- a/test/contrib/es/es-service.spec.ts
+++ b/test/contrib/es/es-service.spec.ts
@@ -1,5 +1,5 @@
 import { Container } from 'internal:typedi';
-import { createFakeClassDecoratorContext } from './utils/fake-context.util';
+import { createFakeClassDecoratorContext } from './test-utils/fake-context.util';
 import { ESService } from 'internal:typedi/contrib/es/es-service.decorator.mjs';
 
 // Due to the testing structure, we can't actually use ES Decorators

--- a/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
+++ b/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
@@ -1,0 +1,25 @@
+
+import { ServiceOptions, AnyServiceDependency, Service, Constructable } from 'internal:typedi';
+import { ESService } from 'internal:typedi/contrib/es/es-service.decorator.mjs';
+import { createFakeClassDecoratorContext } from './fake-context.util';
+
+// To simplify the implementation, we don't define *each* applicable overload
+// here.  Instead, we define just the implementation and cast the wrapper to
+// <typeof Service>.
+function WrappedESServiceDecoratorImpl<T = unknown>(
+  optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
+  maybeDependencies?: AnyServiceDependency[]
+): ClassDecorator {
+    return (targetConstructor) => {
+        const fakeContext: ClassDecoratorContext = createFakeClassDecoratorContext(targetConstructor);
+
+        // Note: These aren't guaranteed, just used to trick TypeScript into being quiet.
+        ESService<T>(
+            optionsOrDependencies as Omit<ServiceOptions<T>, 'dependencies'>,
+            maybeDependencies as AnyServiceDependency[]
+        )(targetConstructor as unknown as Constructable<T>, fakeContext);
+    }
+}
+
+export const WrappedESServiceDecorator = WrappedESServiceDecoratorImpl as typeof Service;
+

--- a/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
+++ b/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
@@ -1,4 +1,3 @@
-
 import { ServiceOptions, AnyServiceDependency, Service, Constructable } from 'internal:typedi';
 import { ESService } from 'internal:typedi/contrib/es/es-service.decorator.mjs';
 import { createFakeClassDecoratorContext } from './fake-context.util';
@@ -10,16 +9,15 @@ function WrappedESServiceDecoratorImpl<T = unknown>(
   optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
   maybeDependencies?: AnyServiceDependency[]
 ): ClassDecorator {
-    return (targetConstructor) => {
-        const fakeContext: ClassDecoratorContext = createFakeClassDecoratorContext(targetConstructor);
+  return targetConstructor => {
+    const fakeContext: ClassDecoratorContext = createFakeClassDecoratorContext(targetConstructor);
 
-        // Note: These aren't guaranteed, just used to trick TypeScript into being quiet.
-        ESService<T>(
-            optionsOrDependencies as Omit<ServiceOptions<T>, 'dependencies'>,
-            maybeDependencies as AnyServiceDependency[]
-        )(targetConstructor as unknown as Constructable<T>, fakeContext);
-    }
+    // Note: These aren't guaranteed, just used to trick TypeScript into being quiet.
+    ESService<T>(
+      optionsOrDependencies as Omit<ServiceOptions<T>, 'dependencies'>,
+      maybeDependencies as AnyServiceDependency[]
+    )(targetConstructor as unknown as Constructable<T>, fakeContext);
+  };
 }
 
 export const WrappedESServiceDecorator = WrappedESServiceDecoratorImpl as typeof Service;
-

--- a/test/contrib/es/test-utils/fake-context.util.ts
+++ b/test/contrib/es/test-utils/fake-context.util.ts
@@ -1,0 +1,12 @@
+export function createFakeClassDecoratorContext<TFunction extends Function>(targetConstructor: TFunction): ClassDecoratorContext<abstract new (...args: any) => any> {
+    return {
+        addInitializer(initializer) {
+            // We can't implement this, and it isn't used by ESService.
+            throw new Error('Not implemented.');
+        },
+        kind: 'class',
+        // TODO: Not sure what goes here, and it isn't used by ESService.
+        metadata: {},
+        name: targetConstructor.name
+    };
+}

--- a/test/contrib/es/test-utils/fake-context.util.ts
+++ b/test/contrib/es/test-utils/fake-context.util.ts
@@ -1,12 +1,14 @@
-export function createFakeClassDecoratorContext<TFunction extends Function>(targetConstructor: TFunction): ClassDecoratorContext<abstract new (...args: any) => any> {
-    return {
-        addInitializer(initializer) {
-            // We can't implement this, and it isn't used by ESService.
-            throw new Error('Not implemented.');
-        },
-        kind: 'class',
-        // TODO: Not sure what goes here, and it isn't used by ESService.
-        metadata: {},
-        name: targetConstructor.name
-    };
+export function createFakeClassDecoratorContext<TFunction extends Function>(
+  targetConstructor: TFunction
+): ClassDecoratorContext<abstract new (...args: any) => any> {
+  return {
+    addInitializer(initializer) {
+      // We can't implement this, and it isn't used by ESService.
+      throw new Error('Not implemented.');
+    },
+    kind: 'class',
+    // TODO: Not sure what goes here, and it isn't used by ESService.
+    metadata: {},
+    name: targetConstructor.name,
+  };
 }

--- a/test/decorators/Service.spec.ts
+++ b/test/decorators/Service.spec.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { Container, ContainerInstance, Service, Token } from 'internal:typedi';
-import { WrappedESServiceDecorator } from '../contrib/es/utils/es-service-decorator-wrapper.util';
+import { WrappedESServiceDecorator } from '../contrib/es/test-utils/es-service-decorator-wrapper.util';
 
 // To ensure conformance between different Service implementations,
 // we wrap some decorators here with stubs which pass them quasi-values.

--- a/test/decorators/Service.spec.ts
+++ b/test/decorators/Service.spec.ts
@@ -19,7 +19,7 @@ interface DecoratorTestScenario {
 
 const DECORATORS_TO_TEST: DecoratorTestScenario[] = [
   { decorator: Service, description: 'main, non-ES', name: 'Service' },
-  { decorator: WrappedESServiceDecorator, description: 'contrib/es/ESService', name: 'ESService' }
+  { decorator: WrappedESServiceDecorator, description: 'contrib/es/ESService', name: 'ESService' },
 ];
 
 describe.each(DECORATORS_TO_TEST)('$name decorator ($description)', ({ decorator: Decorator }) => {


### PR DESCRIPTION
This patch introduces ES Decorators as a contributory package.
These decorators mirror their non-ES counterparts in the main
package.

As the package only contains one decorator, we only have to
focus on the Service decorator.