### PR TITLE
Disable stripInternal in TS config

### DIFF
--- a/.changeset/kind-readers-talk.md
+++ b/.changeset/kind-readers-talk.md
@@ -1,0 +1,5 @@
+---
+'@freshgum/typedi': patch
+---
+
+stripInternal has been disabled in the package's TSConfig due to it breaking fresh installs of the package. This shouldn't affect you unless you rely upon the container's internal `visitor` property, which has its properties mangled to reduce bundle size.

--- a/scripts/tsconfig/tsconfig.base.json
+++ b/scripts/tsconfig/tsconfig.base.json
@@ -22,7 +22,11 @@
       "strictPropertyInitialization": true,
       "strictNullChecks": true,
       "noImplicitAny": true,
-      "stripInternal": true
+
+      // stripInternal is disabled due to it causing issues in bundles, wherein types marked as
+      // @internal were being elided from the build, even when other parts of the package depended
+      // upon them.  See: <https://github.com/freshgum-bubbles/typedi/issues/146>
+      "stripInternal": false
     },
     "exclude": [
       "../../build",


### PR DESCRIPTION
stripInternal is disabled due to it causing
issues in bundles, wherein types marked as
@internal were being elided from the build,
even when other parts of the package depended
upon them.

See: <https://github.com/freshgum-bubbles/typedi/issues/146>

---

The long-term solution to this is migrating to api-extractor,
which has been on the backburner for a while now.