### PR TITLE
fix(docs): use proper identifiers

### DIFF
--- a/docs/docs/examples/nodejs-web-server/implementation.md
+++ b/docs/docs/examples/nodejs-web-server/implementation.md
@@ -197,7 +197,7 @@ class WebServerService {
         response.writeHead(200);
         // highlight-revision-start
         this.database.write('name', params.get('name').then(() => {
-          response.end(`Hello, ${params.name}!`);
+          response.end(`Hello, ${params.get('name')}!`);
         });
         // highlight-revision-end
         break;

--- a/docs/docs/examples/nodejs-web-server/implementation.md
+++ b/docs/docs/examples/nodejs-web-server/implementation.md
@@ -196,7 +196,7 @@ class WebServerService {
       case '/setname':
         response.writeHead(200);
         // highlight-revision-start
-        this.database.write('name', params.name).then(() => {
+        this.database.write('name', params.get('name').then(() => {
           response.end(`Hello, ${params.name}!`);
         });
         // highlight-revision-end

--- a/docs/docs/examples/nodejs-web-server/implementation.md
+++ b/docs/docs/examples/nodejs-web-server/implementation.md
@@ -187,7 +187,7 @@ class WebServerService {
       case '/hello':
         response.writeHead(200);
         // highlight-revision-start
-        this.database.get('name').then(name => {
+        this.database.read('name').then(name => {
           response.end(`Hello, ${name ?? 'unknown person'}!`);
         });
         // highlight-revision-end
@@ -196,7 +196,7 @@ class WebServerService {
       case '/setname':
         response.writeHead(200);
         // highlight-revision-start
-        this.database.set('name', params.name).then(() => {
+        this.database.write('name', params.name).then(() => {
           response.end(`Hello, ${params.name}!`);
         });
         // highlight-revision-end

--- a/docs/docs/examples/nodejs-web-server/implementation.md
+++ b/docs/docs/examples/nodejs-web-server/implementation.md
@@ -61,7 +61,7 @@ export class WebServerService {
   }
 
   protected handleRequest(request: IncomingMessage, response: ServerResponse<IncomingMessage>) {
-    switch (response.url) {
+    switch (request.url) {
       case '/hello':
         response.writeHead(200);
         response.end('Hello!');
@@ -183,7 +183,7 @@ class WebServerService {
     const { searchParams: params } = new URL(request.url ?? '');
     // highlight-revision-end
 
-    switch (response.url) {
+    switch (request.url) {
       case '/hello':
         response.writeHead(200);
         // highlight-revision-start


### PR DESCRIPTION
In the example documentation for the use of TypeDI in a Node.js server, the `url` property in switch statements is being accessed on the `response` object and not on the `request` object.
This PR fixes that