### PR TITLE
Add linting for package.json

### DIFF
--- a/.changeset/breezy-suns-train.md
+++ b/.changeset/breezy-suns-train.md
@@ -8,10 +8,11 @@ Prior to this, it was listed in `package.json` but wasn't importable.
 I'm really sorry about this: [Packaging certainly isn't my strongest point](https://github.com/freshgum-bubbles/typedi/issues/96), and to date, I've caught quite a few painful `package.json`-related errors in production.
 
 The upside to all this is that I'm working on making it better -- in fact, this issue was only caught
-when [adding publint checks for the package](https://github.com/freshgum-bubbles/typedi/pull/167).  publint is an excellent tool that makes sure your package works well across different environments (and like... actually works).
+when [adding publint checks for the package](https://github.com/freshgum-bubbles/typedi/pull/167). publint is an excellent tool that makes sure your package works well across different environments (and like... actually works).
 
 A few other things have been fixed too, namely:
-  - [Loading the package from unpkg now works](https://unpkg.dev/@freshgum/typedi) <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/d9ffcdda32c4414f71f3bc434fefc833e872d01d)</sup>
-  - An error where the `default` export condition may have taken precedence over others <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/8d9b447504be19ea1e4169c45ef025263f6e7a2e)</sup>
+
+- [Loading the package from unpkg now works](https://unpkg.dev/@freshgum/typedi) <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/d9ffcdda32c4414f71f3bc434fefc833e872d01d)</sup>
+- An error where the `default` export condition may have taken precedence over others <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/8d9b447504be19ea1e4169c45ef025263f6e7a2e)</sup>
 
 I hope this changelog entry inspires you to start linting your `package.json`, because dealing with this stuff really sucks.

--- a/.changeset/breezy-suns-train.md
+++ b/.changeset/breezy-suns-train.md
@@ -1,0 +1,13 @@
+---
+'@freshgum/typedi': patch
+---
+
+[SynchronousDisposable is actually usable now.](https://github.com/freshgum-bubbles/typedi/pull/167/commits/5228df1f98e6c13b90aa5c34094b9c312b6992c1)
+Prior to this, it was listed in `package.json` but wasn't importable.
+
+I'm really sorry about this: [Packaging certainly isn't my strongest point](https://github.com/freshgum-bubbles/typedi/issues/96), and to date, I've caught quite a few painful `package.json`-related errors in production.
+
+The upside to all this is that I'm working on making it better -- in fact, this issue was only caught
+when [adding publint checks for the package](https://github.com/freshgum-bubbles/typedi/pull/167).  publint is an excellent tool that makes sure your package works well across different environments (and like... actually works.).
+
+I hope this changelog entry inspires you to start linting your `package.json`, because dealing with this stuff really sucks.

--- a/.changeset/breezy-suns-train.md
+++ b/.changeset/breezy-suns-train.md
@@ -8,6 +8,10 @@ Prior to this, it was listed in `package.json` but wasn't importable.
 I'm really sorry about this: [Packaging certainly isn't my strongest point](https://github.com/freshgum-bubbles/typedi/issues/96), and to date, I've caught quite a few painful `package.json`-related errors in production.
 
 The upside to all this is that I'm working on making it better -- in fact, this issue was only caught
-when [adding publint checks for the package](https://github.com/freshgum-bubbles/typedi/pull/167).  publint is an excellent tool that makes sure your package works well across different environments (and like... actually works.).
+when [adding publint checks for the package](https://github.com/freshgum-bubbles/typedi/pull/167).  publint is an excellent tool that makes sure your package works well across different environments (and like... actually works).
+
+A few other things have been fixed too, namely:
+  - [Loading the package from unpkg now works](https://unpkg.dev/@freshgum/typedi) <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/d9ffcdda32c4414f71f3bc434fefc833e872d01d)</sup>
+  - An error where the `default` export condition may have taken precedence over others <sup>[(commit)](https://github.com/freshgum-bubbles/typedi/pull/167/commits/8d9b447504be19ea1e4169c45ef025263f6e7a2e)</sup>
 
 I hope this changelog entry inspires you to start linting your `package.json`, because dealing with this stuff really sucks.

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -71,6 +71,36 @@ jobs:
       - run: pnpm run test:ci
       - run: pnpm install codecov -g
       - run: codecov -f ./coverage/clover.xml -t ${{ secrets.CODECOV_TOKEN }}
+  publint:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+          registry-url: https://registry.npmjs.org
+      - uses: pnpm/action-setup@v2
+        name: Install pnpm
+        id: pnpm-install
+        with:
+          version: 8.6.1
+      - name: Set PNPM Cache Directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v3
+        name: Restore PNPM Package Cache
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+      - run: pnpm install
+      - run: pnpm run lint:package-json
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "typescript"
   ],
   "scripts": {
-    "build": "npm run build:cjs && npm run build:rollup && npm run build:umd",
+    "build": "npm run build:esm5 && npm run build:rollup && npm run build:umd && npm run build:types",
     "build:clean": "rimraf build",
     "build:clean-esm5": "rimraf ./build/esm5",
     "build:clean-cjs": "rimraf ./build/cjs",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "MIT",
   "private": false,
   "sideEffects": false,
-  "unpkg": "./bundles/typedi.umd.min.js",
+  "unpkg": "./build/bundles/typedi.umd.min.js",
   "types": "./build/types/index.d.mts",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
       "default": "./build/esm5/contrib/transient-ref/index.mjs"
     },
     "./contrib/util/synchronous-disposable": {
-      "types": "./build/esm5/contrib/util/synchronous-disposable.d.mts",
-      "import": "./build/esm5/contrib/util/synchronous-disposable.mjs",
-      "node": "./build/esm5/contrib/util/synchronous-disposable.mjs",
+      "types": "./build/esm5/contrib/util/synchronous-disposable.class.d.mts",
+      "import": "./build/esm5/contrib/util/synchronous-disposable.class.mjs",
+      "node": "./build/esm5/contrib/util/synchronous-disposable.class.mjs",
       "bun": "./src/contrib/util/synchronous-disposable.class.mts",
-      "default": "./build/esm5/contrib/util/synchronous-disposable.mjs"
+      "default": "./build/esm5/contrib/util/synchronous-disposable.class.mjs"
     },
     "./contrib/util/get-service-identifier-type": {
       "types": "./build/esm5/contrib/util/get-service-identifier-type.util.d.mts",

--- a/package.json
+++ b/package.json
@@ -21,37 +21,37 @@
     ".": {
       "types": "./build/esm5/entry/index.d.mts",
       "import": "./build/esm5/entry/index.mjs",
-      "default": "./build/esm5/entry/index.mjs",
       "node": "./build/esm5/entry/index.mjs",
-      "bun": "./src/index.mts"
+      "bun": "./src/index.mts",
+      "default": "./build/esm5/entry/index.mjs"
     },
     "./contrib/es": {
       "types": "./build/esm5/contrib/es/index.d.mts",
       "import": "./build/esm5/contrib/es/index.mjs",
-      "default": "./build/esm5/contrib/es/index.mjs",
       "node": "./build/esm5/contrib/es/index.mjs",
-      "bun": "./src/contrib/es/index.mts"
+      "bun": "./src/contrib/es/index.mts",
+      "default": "./build/esm5/contrib/es/index.mjs"
     },
     "./contrib/transient-ref": {
       "types": "./build/esm5/contrib/transient-ref/index.d.mts",
       "import": "./build/esm5/contrib/transient-ref/index.mjs",
-      "default": "./build/esm5/contrib/transient-ref/index.mjs",
       "node": "./build/esm5/contrib/transient-ref/index.mjs",
-      "bun": "./src/contrib/transient-ref/index.mts"
+      "bun": "./src/contrib/transient-ref/index.mts",
+      "default": "./build/esm5/contrib/transient-ref/index.mjs"
     },
     "./contrib/util/synchronous-disposable": {
       "types": "./build/esm5/contrib/util/synchronous-disposable.d.mts",
       "import": "./build/esm5/contrib/util/synchronous-disposable.mjs",
-      "default": "./build/esm5/contrib/util/synchronous-disposable.mjs",
       "node": "./build/esm5/contrib/util/synchronous-disposable.mjs",
-      "bun": "./src/contrib/util/synchronous-disposable.class.mts"
+      "bun": "./src/contrib/util/synchronous-disposable.class.mts",
+      "default": "./build/esm5/contrib/util/synchronous-disposable.mjs"
     },
     "./contrib/util/get-service-identifier-type": {
       "types": "./build/esm5/contrib/util/get-service-identifier-type.util.d.mts",
       "import": "./build/esm5/contrib/util/get-service-identifier-type.util.mjs",
-      "default": "./build/esm5/contrib/util/get-service-identifier-type.util.mjs",
       "node": "./build/esm5/contrib/util/get-service-identifier-type.util.mjs",
-      "bun": "./src/contrib/util/get-service-identifier-type.util.mts"
+      "bun": "./src/contrib/util/get-service-identifier-type.util.mts",
+      "default": "./build/esm5/contrib/util/get-service-identifier-type.util.mjs"
     }
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "prettier:check": "prettier --check \"**/*.{ts,md,mts,mjs,js,cjs}\"",
     "lint:fix": "eslint --max-warnings 0 --fix --ext .mts src/",
     "lint:check": "eslint --max-warnings 0 --ext .mts src/",
+    "lint:package-json": "publint",
     "docs:api-reference": "rimraf website/build/api-reference && typedoc",
     "test": "jest",
     "test:coverage": "jest --coverage --verbose",

--- a/package.json
+++ b/package.json
@@ -133,6 +133,7 @@
     "jest": "^29.7.0",
     "lint-staged": "^15.0.1",
     "prettier": "^3.0.3",
+    "publint": "^0.2.7",
     "rimraf": "5.0.5",
     "rollup": "^4.0.2",
     "ts-jest": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "prettier:check": "prettier --check \"**/*.{ts,md,mts,mjs,js,cjs}\"",
     "lint:fix": "eslint --max-warnings 0 --fix --ext .mts src/",
     "lint:check": "eslint --max-warnings 0 --ext .mts src/",
-    "lint:package-json": "publint",
+    "lint:package-json": "npm run build && publint",
     "docs:api-reference": "rimraf website/build/api-reference && typedoc",
     "test": "jest",
     "test:coverage": "jest --coverage --verbose",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ devDependencies:
   prettier:
     specifier: ^3.0.3
     version: 3.0.3
+  publint:
+    specifier: ^0.2.7
+    version: 0.2.7
   rimraf:
     specifier: 5.0.5
     version: 5.0.5
@@ -3126,6 +3129,13 @@ packages:
       safer-buffer: 2.1.2
     dev: true
 
+  /ignore-walk@5.0.1:
+    resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      minimatch: 5.1.6
+    dev: true
+
   /ignore@5.2.4:
     resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
     engines: {node: '>= 4'}
@@ -4281,6 +4291,11 @@ packages:
     engines: {node: '>= 8.0.0'}
     dev: true
 
+  /mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+    dev: true
+
   /ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
     dev: true
@@ -4327,6 +4342,29 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+    dev: true
+
+  /npm-bundled@2.0.1:
+    resolution: {integrity: sha512-gZLxXdjEzE/+mOstGDqR6b0EkhJ+kM6fxM6vUuckuctuVPh80Q6pw/rSZj9s4Gex9GxWtIicO1pc8DB9KZWudw==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dependencies:
+      npm-normalize-package-bin: 2.0.0
+    dev: true
+
+  /npm-normalize-package-bin@2.0.0:
+    resolution: {integrity: sha512-awzfKUO7v0FscrSpRoogyNm0sajikhBWpU0QMrW09AMi9n1PoKU6WaIqUzuJSQnpciZZmJ/jMZ2Egfmb/9LiWQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    dev: true
+
+  /npm-packlist@5.1.3:
+    resolution: {integrity: sha512-263/0NGrn32YFYi4J533qzrQ/krmmrWwhKkzwTuM4f/07ug51odoaNjUexxO4vxlzURHcmYMH1QjvHjsNDKLVg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+    dependencies:
+      glob: 8.1.0
+      ignore-walk: 5.0.1
+      npm-bundled: 2.0.1
+      npm-normalize-package-bin: 2.0.0
     dev: true
 
   /npm-run-path@4.0.1:
@@ -4580,6 +4618,16 @@ packages:
     resolution: {integrity: sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==}
     dev: true
 
+  /publint@0.2.7:
+    resolution: {integrity: sha512-tLU4ee3110BxWfAmCZggJmCUnYWgPTr0QLnx08sqpLYa8JHRiOudd+CgzdpfU5x5eOaW2WMkpmOrFshRFYK7Mw==}
+    engines: {node: '>=16'}
+    hasBin: true
+    dependencies:
+      npm-packlist: 5.1.3
+      picocolors: 1.0.0
+      sade: 1.8.1
+    dev: true
+
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -4774,6 +4822,13 @@ packages:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
     dependencies:
       queue-microtask: 1.2.3
+    dev: true
+
+  /sade@1.8.1:
+    resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
+    engines: {node: '>=6'}
+    dependencies:
+      mri: 1.2.0
     dev: true
 
   /safe-array-concat@1.0.1:


### PR DESCRIPTION
Quite a few times I've found that the `package.json` doesn't actually work in production.
This is annoying. Very, very annoying. <sup>This change fixes annoying issues like #165, too.</sup>

So let's fix it with linting!  I've added `publint` to the package to hopefully prevent these
problems in future.  I'd like to pair it with something knowledgeable when it comes to
TypeScript packaging errors, too.

Fixes #168
Fixes #169