### PR TITLE
Stop defaulting the container ID parameter to "default" in .of[...] methods

### DIFF
--- a/.changeset/gentle-cougars-hope.md
+++ b/.changeset/gentle-cougars-hope.md
@@ -1,0 +1,45 @@
+---
+'@freshgum/typedi': major
+---
+
+**This is a breaking change to the core API**.
+
+The container no longer provides a default `containerId` parameter for the following methods:
+
+- `ContainerInstance.ofChild`
+- `ContainerInstance.of`
+- `static ContainerInstance.of`
+
+In retrospect, this was a bad idea. I'll explain this further with the code below.
+
+```ts
+import { Container } from '@freshgum/typedi';
+
+const c1 = Container.ofChild(Symbol('c1'));
+
+@Service({ container: c1 }, [])
+class MyService {}
+
+const c2 = c1.ofChild();
+
+c2.get(MyService); // -> ServiceNotFoundError
+```
+
+Ignoring the hints above, the problem with this code may not be obvious at a first glance.
+While you'd _assume_ the call to `c1.ofChild()` returns a child container of `c1` (which
+would then inherit its services), it's actually just returned an exact reference to the
+default container (`Container` itself.)
+
+This raises a great deal of ambiguity, as it's no longer immediately clear whether a call
+to these methods does as you would initially expect.
+
+Therefore, type-safe calls to these methods without a container ID will now raise an error at
+compile-time.
+The signature of these methods has been changed to require the container ID parameter.
+
+**Migrating** away from this behaviour is quite simple: replace all calls to `X.ofChild()`
+with a reference to the default container (`Container`).
+
+Whilst I'm not a fan of making breaking changes to the Container, I believe this one makes
+sense in the pursuit of a safer, more streamlined API -- if you experience any issues with
+this, please feel free to open a GitHub issue.

--- a/src/container-instance.class.mts
+++ b/src/container-instance.class.mts
@@ -950,7 +950,7 @@ export class ContainerInstance implements Disposable {
    * ContainerInstance.of('my-new-special-container', myOtherContainer);
    * ```
    *
-   * @param containerId The ID of the container to resolve or create.  Defaults to "default".
+   * @param containerId The ID of the container to resolve or create.
    * @param parent The parent of the container, or null to explicitly signal that one should not be provided.
    * Defaults to the default container.
    * @param options The options to supplement how the container is created.
@@ -961,7 +961,7 @@ export class ContainerInstance implements Disposable {
    * if one already exists.
    */
   public static of<TOptions extends CreateContainerOptions>(
-    containerId: ContainerIdentifier = 'default',
+    containerId: ContainerIdentifier,
     parent: ContainerInstance | null = defaultContainer,
     options?: TOptions
   ): CreateContainerResult<TOptions> {
@@ -1049,7 +1049,7 @@ export class ContainerInstance implements Disposable {
   /**
    * Gets a separate container instance for the given instance id.
    *
-   * @param containerId The ID of the container to resolve or create.  Defaults to "default".
+   * @param containerId The ID of the container to resolve or create.
    *
    * @example
    * ```
@@ -1063,7 +1063,7 @@ export class ContainerInstance implements Disposable {
    * with the same name if one already exists.
    */
   public of<TOptions extends CreateContainerOptions>(
-    containerId?: ContainerIdentifier,
+    containerId: ContainerIdentifier,
     options?: TOptions
   ): CreateContainerResult<TOptions> {
     // Todo: make this get the constructor at runtime to aid
@@ -1075,7 +1075,7 @@ export class ContainerInstance implements Disposable {
   /**
    * Create a registry with the specified ID, with this instance as its parent.
    *
-   * @param containerId The ID of the container to resolve or create.  Defaults to "default".
+   * @param containerId The ID of the container to resolve or create.
    *
    * @returns The newly-created {@link ContainerInstance}, or the pre-existing container
    * with the same name if one already exists.
@@ -1084,7 +1084,7 @@ export class ContainerInstance implements Disposable {
    * This exception is thrown if the container has been disposed.
    */
   public ofChild<TOptions extends CreateContainerOptions>(
-    containerId?: ContainerIdentifier,
+    containerId: ContainerIdentifier,
     options?: TOptions
   ): CreateContainerResult<TOptions> {
     this.throwIfDisposed();


### PR DESCRIPTION
**This is a breaking change to the core API**.

The container no longer provides a default `containerId` parameter for the following methods:
  - `ContainerInstance.ofChild`
  - `ContainerInstance.of`
  - `static ContainerInstance.of`

In retrospect, this was a bad idea.  I'll explain this further with the code below.

```ts
import { Container } from '@freshgum/typedi';

const c1 = Container.ofChild(Symbol('c1'));

@Service({ container: c1 }, [ ])
class MyService { }

const c2 = c1.ofChild();

c2.get(MyService); // -> ServiceNotFoundError
```

Ignoring the hints above, the problem with this code may not be obvious at a first glance.
While you'd *assume* the call to `c1.ofChild()` returns a child container of `c1` (which
would then inherit its services), it's actually just returned an exact reference to the
default container (`Container` itself.)

This raises a great deal of ambiguity, as it's no longer immediately clear whether a call
to these methods does as you would initially expect.

Therefore, type-safe calls to these methods without a container ID will now raise an error at
compile-time.
The signature of these methods has been changed to require the container ID parameter.

**Migrating** away from this behaviour is quite simple: replace all calls to `X.ofChild()`
with a reference to the default container (`Container`).

Whilst I'm not a fan of making breaking changes to the Container, I believe this one makes
sense in the pursuit of a safer, more streamlined API -- if you experience any issues with
this, please feel free to open a GitHub issue.