### PR TITLE
Change ESService return type

### DIFF
--- a/.changeset/short-dogs-reflect.md
+++ b/.changeset/short-dogs-reflect.md
@@ -1,0 +1,14 @@
+---
+'@freshgum/typedi': minor
+---
+
+Currently, ESService does not return its target. The usage of the `Constructable` type also causes issues, as it makes
+the decorator return the wrong type.
+
+This causes the following error:
+
+> "Decorator function return type 'void | Constructable<AuthStoreService>' is not assignable to type 'void | typeof AuthStoreService'".
+
+This occured when I added the decorator to a class which extended another.
+
+I've updated the decorator to return the target, as opposed to a wrapped version, and this seems to have fixed the issue.

--- a/src/contrib/es/es-service.decorator.mts
+++ b/src/contrib/es/es-service.decorator.mts
@@ -35,9 +35,7 @@ import { ESClassDecorator } from '../util/es-class-decorator.type.mjs';
  *
  * @returns A decorator which is then used upon a class.
  */
-export function ESService<TInstance = unknown, TClass extends Constructable<TInstance> = Constructable<TInstance>>(
-  dependencies: AnyServiceDependency[]
-): ESClassDecorator<TClass>;
+export function ESService<T extends Function>(dependencies: AnyServiceDependency[]): ESClassDecorator<T>;
 
 /**
  * Marks class as a service that can be injected using Container.
@@ -76,10 +74,10 @@ export function ESService<TInstance = unknown, TClass extends Constructable<TIns
  *
  * @returns A decorator which is then used upon a class.
  */
-export function ESService<TInstance = unknown, TClass extends Constructable<TInstance> = Constructable<TInstance>>(
-  options: Omit<ServiceOptions<TInstance>, 'dependencies'>,
+export function ESService<T extends Function>(
+  options: Omit<ServiceOptions<T>, 'dependencies'>,
   dependencies: AnyServiceDependency[]
-): ESClassDecorator<TClass>;
+): ESClassDecorator<T>;
 
 /**
  * Marks class as a service that can be injected using Container.
@@ -117,26 +115,25 @@ export function ESService<TInstance = unknown, TClass extends Constructable<TIns
  *
  * @returns A decorator which is then used upon a class.
  */
-export function ESService<TInstance = unknown, TClass extends Constructable<TInstance> = Constructable<TInstance>>(
-  options: ServiceOptionsWithDependencies<TInstance>
-): ESClassDecorator<TClass>;
+export function ESService<T extends Function>(
+  options: ServiceOptionsWithDependencies<Constructable<unknown>>
+): ESClassDecorator<T>;
 
-export function ESService<TInstance = unknown, TClass extends Constructable<TInstance> = Constructable<TInstance>>(
-  optionsOrDependencies:
-    | Omit<ServiceOptions<TInstance>, 'dependencies'>
-    | ServiceOptions<TInstance>
-    | AnyServiceDependency[],
+export function ESService<T extends Function>(
+  optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
   maybeDependencies?: AnyServiceDependency[]
-): ESClassDecorator<TClass> {
-  return (target: TClass, context: ClassDecoratorContext) => {
+): ESClassDecorator<T> {
+  return (target: T, context: ClassDecoratorContext) => {
     // This is probably overcautious.
     if (context.kind !== 'class') {
       throw new Error('@ESService() must only be used to decorate classes.');
     }
 
     Service(
-      optionsOrDependencies as ServiceOptionsWithoutDependencies<TClass>,
+      optionsOrDependencies as ServiceOptionsWithoutDependencies<T>,
       maybeDependencies as AnyServiceDependency[]
     )(target);
+
+    return target;
   };
 }

--- a/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
+++ b/test/contrib/es/test-utils/es-service-decorator-wrapper.util.ts
@@ -5,18 +5,18 @@ import { createFakeClassDecoratorContext } from './fake-context.util';
 // To simplify the implementation, we don't define *each* applicable overload
 // here.  Instead, we define just the implementation and cast the wrapper to
 // <typeof Service>.
-function WrappedESServiceDecoratorImpl<T = unknown>(
+function WrappedESServiceDecoratorImpl<T extends { new (): TReturn }, TReturn>(
   optionsOrDependencies: Omit<ServiceOptions<T>, 'dependencies'> | ServiceOptions<T> | AnyServiceDependency[],
   maybeDependencies?: AnyServiceDependency[]
-): ClassDecorator {
-  return targetConstructor => {
+): { (t: T): void } {
+  return <TTarget extends T>(targetConstructor: TTarget) => {
     const fakeContext: ClassDecoratorContext = createFakeClassDecoratorContext(targetConstructor);
 
     // Note: These aren't guaranteed, just used to trick TypeScript into being quiet.
     ESService<T>(
       optionsOrDependencies as Omit<ServiceOptions<T>, 'dependencies'>,
       maybeDependencies as AnyServiceDependency[]
-    )(targetConstructor as unknown as Constructable<T>, fakeContext);
+    )(targetConstructor, fakeContext);
   };
 }
 


### PR DESCRIPTION
Currently, ESService does not return its target.
The usage of the Constructable type also causes
issues, as it makes the decorator return the wrong
type.

This causes the following error:
"Decorator function return type 'void |
Constructable<AuthStoreService>' is not
assignable to type 'void | typeof AuthStoreService'".

This occured when I added the decorator to a class
which extended another.

I've updated the decorator to return the target, as
opposed to a wrapped version, and this seems to have
fixed the issue.